### PR TITLE
Feat/60 admin service develop

### DIFF
--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -29,6 +29,8 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+        ports:
+          - 5432:5432 # maps port
 
     steps:
       - name: Check access

--- a/src/main/java/com/sparta/first/project/eighteen/domain/users/AdminController.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/users/AdminController.java
@@ -27,11 +27,18 @@ import lombok.extern.slf4j.Slf4j;
 public class AdminController {
 	private final AdminService adminService;
 
+	/**
+	 * 페이징 기본값의 경우 ()으로 표기
+	 * page(1), size(10), sort(SIGN_UP_DATE_ASC)
+	 * 조회 시작 기간, 조회 종료 기간, 가입 형태, 역할 등에 따라 검색 가능.
+	 * @param requestDto
+	 * @return
+	 */
 	@GetMapping("/users")
 	@PreAuthorize("hasAnyRole('ROLE_MANAGER', 'ROLE_MASTER')")
 	public ResponseEntity<ApiResponse<PagedModel<AdminUserSearchResponseDto>>> getAllUsers(
-		@ModelAttribute AdminUserSearchRequestDto requestDto) {
-
+		@ModelAttribute AdminUserSearchRequestDto requestDto
+	) {
 		PagedModel<AdminUserSearchResponseDto> allUsers = adminService.findAllUsers(requestDto);
 
 		return ResponseEntity.ok(ApiResponse.ok("모든 회원 조회", allUsers));

--- a/src/main/java/com/sparta/first/project/eighteen/domain/users/AdminController.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/users/AdminController.java
@@ -14,8 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.sparta.first.project.eighteen.common.dto.ApiResponse;
 import com.sparta.first.project.eighteen.domain.users.dtos.AdminUserSearchRequestDto;
 import com.sparta.first.project.eighteen.domain.users.dtos.AdminUserSearchResponseDto;
-import com.sparta.first.project.eighteen.domain.users.dtos.UserResponseDto;
-import com.sparta.first.project.eighteen.domain.users.dtos.UserUpdateRequestDto;
+import com.sparta.first.project.eighteen.domain.users.dtos.AdminUserUpdateRequestDto;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -40,19 +39,11 @@ public class AdminController {
 
 	@PutMapping("/users/{userId}")
 	@PreAuthorize("hasAnyRole('ROLE_MANAGER', 'ROLE_MASTER')")
-	public ResponseEntity<ApiResponse<UserResponseDto>> modifyUser(
+	public ResponseEntity<ApiResponse<AdminUserSearchResponseDto>> modifyUser(
 		@PathVariable String userId,
-		@Valid @RequestBody UserUpdateRequestDto requestDto) {
-		UserResponseDto response = adminService.modifyUser(userId, requestDto);
+		@Valid @RequestBody AdminUserUpdateRequestDto requestDto) {
 
-		log.info("수정 : {}", response);
-		UserResponseDto mockData = UserResponseDto.builder()
-			.username("testUser")
-			.nickname("테스트회원")
-			.phone("012-3456-7890")
-			.email("test@test.io")
-			.address("서울시 광화문구")
-			.build();
+		AdminUserSearchResponseDto response = adminService.modifyUser(userId, requestDto);
 
 		return ResponseEntity.ok(ApiResponse.ok("회원 정보 수정", response));
 	}

--- a/src/main/java/com/sparta/first/project/eighteen/domain/users/AdminService.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/users/AdminService.java
@@ -1,5 +1,7 @@
 package com.sparta.first.project.eighteen.domain.users;
 
+import java.util.UUID;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -11,9 +13,10 @@ import org.springframework.transaction.annotation.Transactional;
 import com.sparta.first.project.eighteen.common.exception.BaseException;
 import com.sparta.first.project.eighteen.domain.users.dtos.AdminUserSearchRequestDto;
 import com.sparta.first.project.eighteen.domain.users.dtos.AdminUserSearchResponseDto;
-import com.sparta.first.project.eighteen.domain.users.dtos.UserResponseDto;
-import com.sparta.first.project.eighteen.domain.users.dtos.UserUpdateRequestDto;
+import com.sparta.first.project.eighteen.domain.users.dtos.AdminUserUpdateRequestDto;
+import com.sparta.first.project.eighteen.model.users.Users;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -32,10 +35,15 @@ public class AdminService {
 	}
 
 	@Transactional
-	public UserResponseDto modifyUser(String userId, UserUpdateRequestDto userRequestDto) {
-		userRepository.findByUsername(userId)
+	public AdminUserSearchResponseDto modifyUser(String userId, @Valid AdminUserUpdateRequestDto userRequestDto) {
+		Users origin = userRepository.findById(UUID.fromString(userId))
 			.orElseThrow(() -> new BaseException("유저를 찾을 수 없습니다", -1, HttpStatus.NOT_FOUND));
-		return null;
+
+		Users updated = userRequestDto.toEntity();
+
+		origin.adminUserUpdate(updated);
+
+		return AdminUserSearchResponseDto.from(origin);
 	}
 
 }

--- a/src/main/java/com/sparta/first/project/eighteen/domain/users/AdminService.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/users/AdminService.java
@@ -26,12 +26,14 @@ public class AdminService {
 	private final UserRepository userRepository;
 
 	public PagedModel<AdminUserSearchResponseDto> findAllUsers(AdminUserSearchRequestDto requestDto) {
-		Pageable pageable = PageRequest.of(requestDto.getPage(), requestDto.getSize());
+		Pageable pageable = PageRequest.of(requestDto.getPage(), requestDto.getSize(),
+			requestDto.getSort().toSort());
 
-		Page<AdminUserSearchResponseDto> allUsers = userRepository.findAllByRole(requestDto.getRole(), pageable)
+		Page<AdminUserSearchResponseDto> users = userRepository.searchUser(requestDto, pageable)
 			.map(AdminUserSearchResponseDto::from);
+		
+		return new PagedModel<>(users);
 
-		return new PagedModel<>(allUsers);
 	}
 
 	@Transactional

--- a/src/main/java/com/sparta/first/project/eighteen/domain/users/UserRepository.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/users/UserRepository.java
@@ -3,16 +3,10 @@ package com.sparta.first.project.eighteen.domain.users;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.sparta.first.project.eighteen.model.users.Role;
 import com.sparta.first.project.eighteen.model.users.Users;
 
-public interface UserRepository extends JpaRepository<Users, UUID> {
+public interface UserRepository extends JpaRepository<Users, UUID>, UserSearchRepository {
 	Optional<Users> findByUsername(String username);
-
-	Page<Users> findAllByRole(Role role, Pageable pageable);
-
 }

--- a/src/main/java/com/sparta/first/project/eighteen/domain/users/UserSearchRepository.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/users/UserSearchRepository.java
@@ -1,0 +1,11 @@
+package com.sparta.first.project.eighteen.domain.users;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.sparta.first.project.eighteen.domain.users.dtos.AdminUserSearchRequestDto;
+import com.sparta.first.project.eighteen.model.users.Users;
+
+public interface UserSearchRepository {
+	Page<Users> searchUser(AdminUserSearchRequestDto requestDto, Pageable pageable);
+}

--- a/src/main/java/com/sparta/first/project/eighteen/domain/users/UserSearchRepositoryImpl.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/users/UserSearchRepositoryImpl.java
@@ -1,0 +1,99 @@
+package com.sparta.first.project.eighteen.domain.users;
+
+import static com.sparta.first.project.eighteen.model.users.QUsers.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.first.project.eighteen.domain.users.dtos.AdminUserSearchRequestDto;
+import com.sparta.first.project.eighteen.model.users.QUsers;
+import com.sparta.first.project.eighteen.model.users.Role;
+import com.sparta.first.project.eighteen.model.users.SignUpType;
+import com.sparta.first.project.eighteen.model.users.Users;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class UserSearchRepositoryImpl implements UserSearchRepository {
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Page<Users> searchUser(AdminUserSearchRequestDto requestDto, Pageable pageable) {
+		List<Users> users = queryFactory.selectFrom(QUsers.users)
+			.where(
+				dateBetween(requestDto.getDateStart(), requestDto.getDateEnd()),
+				roleEquals(requestDto.getRole()),
+				signUpTypeEquals(requestDto.getSignUpType()),
+				roleExceptAdmin()
+			)
+			.orderBy(getAllOrderSpecifiers(pageable).toArray(new OrderSpecifier[] {}))
+			.offset((long)requestDto.getPage() * requestDto.getSize())
+			.limit(requestDto.getSize())
+			.fetch();
+
+		return new PageImpl<>(users, pageable, countUsers(requestDto));
+	}
+
+	/**
+	 * 시작일 ~ 종료일 사이의 유저 검색
+	 * @param dateStart : 조회하려는 시작일
+	 * @param dateEnd : 조회하려는 종료일
+	 * @return
+	 */
+	private BooleanExpression dateBetween(LocalDateTime dateStart, LocalDateTime dateEnd) {
+		// 두 날짜 모두 있으면 사이 기간
+		if (dateStart != null && dateEnd != null) {
+			return users.createdAt.between(dateStart, dateEnd);
+		}
+		// 시작일만 있으면 시작일 이후
+		if (dateStart != null) {
+			return users.createdAt.after(dateStart);
+		}
+		// 종료일만 있으면 종료기간 전까지
+		if (dateEnd != null) {
+			return users.createdAt.before(dateEnd);
+		}
+		return null;
+	}
+
+	private BooleanExpression roleEquals(Role role) {
+		return role != null ? users.role.eq(role) : null;
+	}
+
+	private BooleanExpression roleExceptAdmin() {
+		return users.role.ne(Role.MASTER).and(
+			users.role.ne(Role.MANAGER)
+		);
+	}
+
+	private BooleanExpression signUpTypeEquals(SignUpType signUpType) {
+		return signUpType != null ? users.signUpType.eq(signUpType) : null;
+	}
+
+	private List<OrderSpecifier<?>> getAllOrderSpecifiers(Pageable pageable) {
+		Sort sort = pageable.getSort();
+		Order direction = sort.getOrderFor("createdAt").isAscending() ? Order.ASC : Order.DESC;
+		return List.of(new OrderSpecifier<>(direction, users.createdAt));
+
+	}
+
+	private Long countUsers(AdminUserSearchRequestDto requestDto) {
+		return queryFactory.select(users.count())
+			.from(users)
+			.where(
+				roleEquals(requestDto.getRole()),
+				signUpTypeEquals(requestDto.getSignUpType()),
+				dateBetween(requestDto.getDateStart(), requestDto.getDateEnd())
+			)
+			.fetchOne();
+	}
+}

--- a/src/main/java/com/sparta/first/project/eighteen/domain/users/dtos/AdminUserSearchRequestDto.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/users/dtos/AdminUserSearchRequestDto.java
@@ -1,14 +1,42 @@
 package com.sparta.first.project.eighteen.domain.users.dtos;
 
-import com.sparta.first.project.eighteen.model.users.Role;
+import java.time.LocalDateTime;
 
-import lombok.AllArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.sparta.first.project.eighteen.model.users.Role;
+import com.sparta.first.project.eighteen.model.users.SignUpType;
+
+import jakarta.validation.constraints.Positive;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
-@AllArgsConstructor
+@ToString
 public class AdminUserSearchRequestDto {
-	private int page;
-	private int size;
+	@Positive
+	private int page = 1;
+
+	@Positive
+	private int size = 10;
+
 	private Role role;
+	private SignUpType signUpType; // 가입 타입에 따라
+	private LocalDateTime dateStart; // 조회 시작일
+	private LocalDateTime dateEnd; // 조회 종료일
+
+	@JsonSetter(nulls = Nulls.SKIP)
+	private UserSortType sort = UserSortType.SIGN_UP_DATE_ASC; // 가입일 기본값 오름차순
+
+	// page, size, sort의 경우 파라미터 전달이 되지 않은 경우 ->
+	public AdminUserSearchRequestDto(int page, int size, Role role, SignUpType signUpType, LocalDateTime dateStart,
+		LocalDateTime dateEnd, UserSortType sort) {
+		this.page = page != 0 ? page - 1 : this.page;
+		this.size = size != 0 ? size : this.size;
+		this.sort = sort != null ? sort : this.sort;
+		this.role = role;
+		this.signUpType = signUpType;
+		this.dateStart = dateStart;
+		this.dateEnd = dateEnd;
+	}
 }

--- a/src/main/java/com/sparta/first/project/eighteen/domain/users/dtos/AdminUserSearchResponseDto.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/users/dtos/AdminUserSearchResponseDto.java
@@ -1,5 +1,6 @@
 package com.sparta.first.project.eighteen.domain.users.dtos;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import com.sparta.first.project.eighteen.model.users.Role;
@@ -22,6 +23,7 @@ public class AdminUserSearchResponseDto {
 	private String email;
 	private SignUpType signUpType;
 	private Role role;
+	private LocalDateTime createdAt;
 
 	public static AdminUserSearchResponseDto from(Users users) {
 		return AdminUserSearchResponseDto.builder()
@@ -31,6 +33,7 @@ public class AdminUserSearchResponseDto {
 			.email(users.getEmail())
 			.role(users.getRole())
 			.signUpType(users.getSignUpType())
+			.createdAt(users.getCreatedAt())
 			.build();
 	}
 }

--- a/src/main/java/com/sparta/first/project/eighteen/domain/users/dtos/AdminUserUpdateRequestDto.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/users/dtos/AdminUserUpdateRequestDto.java
@@ -1,4 +1,29 @@
 package com.sparta.first.project.eighteen.domain.users.dtos;
 
+import com.sparta.first.project.eighteen.model.users.Role;
+import com.sparta.first.project.eighteen.model.users.Users;
+
+import jakarta.validation.constraints.Email;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class AdminUserUpdateRequestDto {
+	@Email
+	private String email;
+	private Role role;
+	private String password;
+
+	public Users toEntity() {
+		return Users.builder()
+			.email(this.email)
+			.role(this.role)
+			.userPassword(this.password)
+			.build();
+	}
 }

--- a/src/main/java/com/sparta/first/project/eighteen/domain/users/dtos/UserSortType.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/users/dtos/UserSortType.java
@@ -1,0 +1,31 @@
+package com.sparta.first.project.eighteen.domain.users.dtos;
+
+import org.springframework.data.domain.Sort;
+
+public enum UserSortType {
+	SIGN_UP_DATE_ASC(Sort.Direction.ASC, Field.CREATED_AT),
+	SIGN_UP_DATE_DESC(Sort.Direction.DESC, Field.CREATED_AT);
+	private final Sort.Direction direction;
+	private final String properties;
+
+	UserSortType(Sort.Direction direction, String properties) {
+		this.direction = direction;
+		this.properties = properties;
+	}
+
+	public String getProperties() {
+		return properties;
+	}
+
+	public Sort.Direction getDirection() {
+		return direction;
+	}
+
+	public Sort toSort() {
+		return Sort.by(this.getDirection(), this.getProperties());
+	}
+
+	public static class Field { // 등급이나 주문 횟수 등 추가 가능
+		public static final String CREATED_AT = "createdAt";
+	}
+}

--- a/src/main/java/com/sparta/first/project/eighteen/model/users/Users.java
+++ b/src/main/java/com/sparta/first/project/eighteen/model/users/Users.java
@@ -67,4 +67,18 @@ public class Users extends BaseEntity {
 		Optional.ofNullable(update.getUserPhone()).ifPresent(phone -> this.userPhone = phone);
 		Optional.ofNullable(update.getUserAddress()).ifPresent(address -> this.userAddress = address);
 	}
+
+	/**
+	 * 관리자 권한으로 유저 수정
+	 * 이 때는 비밀번호, 권한, 이메일에 대해서 변경해줄 수 있음.
+	 *
+	 * TODO: 추후 비밀번호를 직접 입력받아서 수정하는 것이 아닌 시스템 내부적으로 생성해서 수정하도록 변경
+	 *
+	 * @param update
+	 */
+	public void adminUserUpdate(Users update) {
+		Optional.ofNullable(update.getEmail()).ifPresent(email -> this.email = email);
+		Optional.ofNullable(update.getUserPassword()).ifPresent(password -> this.userPassword = password);
+		Optional.ofNullable(update.getRole()).ifPresent(role -> this.role = role);
+	}
 }

--- a/src/test/java/com/sparta/first/project/eighteen/domain/users/DeletedUserTest.java
+++ b/src/test/java/com/sparta/first/project/eighteen/domain/users/DeletedUserTest.java
@@ -1,0 +1,34 @@
+package com.sparta.first.project.eighteen.domain.users;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+@Transactional
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@WebMvcTest({UserController.class})
+public class DeletedUserTest {
+
+	@Autowired
+	WebApplicationContext ac;
+
+	MockMvc mvc;
+
+	@Autowired
+	UserRepository userRepository;
+
+	@Autowired
+	UserService userService;
+
+	@BeforeEach
+	void setUp() {
+		mvc = MockMvcBuilders.webAppContextSetup(ac)
+			.build();
+	}
+
+}

--- a/src/test/java/com/sparta/first/project/eighteen/domain/users/LoginTest.java
+++ b/src/test/java/com/sparta/first/project/eighteen/domain/users/LoginTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -25,6 +26,7 @@ import com.sparta.first.project.eighteen.domain.users.dtos.LoginRequestDto;
 
 import lombok.extern.slf4j.Slf4j;
 
+@ActiveProfiles("test")
 @SpringBootTest
 @AutoConfigureMockMvc
 @Slf4j

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -15,3 +15,7 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+
+  sql:
+    init:
+      mode: never


### PR DESCRIPTION
## 관련 이슈
- #60 

## 변경 타입
- [ ] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
    - 관리자 권한으로 유저 검색 시 유저 권한에 따라 조회하는 기능만 있었음.

- **to-be**
    - 유저 검색 시 다양한 조건(기간 내 가입한 회원, 유저 권한, 유저 가입 형태)에 따라 검색할 수 있도록 수정
    - 관리자가 유저의 이메일, 비밀번호 등을 수정할 수 있는 기능 구현

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)