### PR TITLE
Feat/50-storeservice

### DIFF
--- a/src/main/java/com/sparta/first/project/eighteen/domain/reviews/ReviewRepository.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/reviews/ReviewRepository.java
@@ -1,10 +1,15 @@
 package com.sparta.first.project.eighteen.domain.reviews;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.sparta.first.project.eighteen.model.reviews.Reviews;
+import com.sparta.first.project.eighteen.model.stores.Stores;
 
 public interface ReviewRepository extends JpaRepository<Reviews, UUID> {
+	int countByStoreId(Stores storeId);
+
+	List<Integer> findReviewRatingByStoreId(Stores storeId);
 }

--- a/src/main/java/com/sparta/first/project/eighteen/domain/reviews/ReviewRepository.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/reviews/ReviewRepository.java
@@ -11,5 +11,5 @@ import com.sparta.first.project.eighteen.model.stores.Stores;
 public interface ReviewRepository extends JpaRepository<Reviews, UUID> {
 	int countByStoreId(Stores storeId);
 
-	List<Integer> findReviewRatingByStoreId(Stores storeId);
+	List<Reviews> findReviewRatingByStoreId(Stores storeId);
 }

--- a/src/main/java/com/sparta/first/project/eighteen/domain/stores/StoreController.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/stores/StoreController.java
@@ -1,14 +1,13 @@
 package com.sparta.first.project.eighteen.domain.stores;
 
-import java.util.List;
 import java.util.UUID;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedModel;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -21,6 +20,7 @@ import com.sparta.first.project.eighteen.common.security.UserDetailsImpl;
 import com.sparta.first.project.eighteen.domain.stores.dtos.StoreListResponseDto;
 import com.sparta.first.project.eighteen.domain.stores.dtos.StoreRequestDto;
 import com.sparta.first.project.eighteen.domain.stores.dtos.StoreResponseDto;
+import com.sparta.first.project.eighteen.domain.stores.dtos.StoreSearchDto;
 import com.sparta.first.project.eighteen.domain.stores.dtos.StoreUpdateRequestDto;
 import com.sparta.first.project.eighteen.model.users.Role;
 
@@ -62,9 +62,11 @@ public class StoreController {
 	 * @return : 식당 목록 반환
 	 */
 	@GetMapping
-	public ResponseEntity<ApiResponse<Page<StoreListResponseDto>>> getStores(Pageable pageable){
-		log.info("getAllStoreList 요청 들어옴");
-		Page<StoreListResponseDto> responseDtos = storeService.getStores(pageable);
+	public ResponseEntity<ApiResponse<PagedModel<StoreListResponseDto>>> getStores(
+		@AuthenticationPrincipal UserDetailsImpl userDetails,
+		@ModelAttribute StoreSearchDto searchDto){
+		log.info("getStores 요청 들어옴");
+		PagedModel<StoreListResponseDto> responseDtos = storeService.getStores(userDetails.getUsername(), searchDto);
 		return ResponseEntity.ok(ApiResponse.ok("성공", responseDtos));
 	}
 

--- a/src/main/java/com/sparta/first/project/eighteen/domain/stores/StoreController.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/stores/StoreController.java
@@ -2,7 +2,9 @@ package com.sparta.first.project.eighteen.domain.stores;
 
 import java.util.UUID;
 
+import org.apache.tomcat.util.bcel.Const;
 import org.springframework.data.web.PagedModel;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,7 +17,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.sparta.first.project.eighteen.common.constants.Constant;
 import com.sparta.first.project.eighteen.common.dto.ApiResponse;
+import com.sparta.first.project.eighteen.common.exception.BaseException;
 import com.sparta.first.project.eighteen.common.security.UserDetailsImpl;
 import com.sparta.first.project.eighteen.domain.stores.dtos.StoreListResponseDto;
 import com.sparta.first.project.eighteen.domain.stores.dtos.StoreRequestDto;
@@ -46,11 +50,9 @@ public class StoreController {
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
 		@RequestBody StoreRequestDto storeRequestDto) {
 
-		// userDetails 담긴 유저는 MASTER 이어야만 함
-		// MASTER 만 가게 생성 가능 (가게 생성 시 OWNER를 넣어주는 방식으로 진행)
 		if (storeService.findUserRole(userDetails.getUsername()) != Role.MASTER) {
 			log.info("MASTER가 아닌 사용자");
-			throw new IllegalArgumentException("해당 사용자는 식당을 생성할 수 없습니다.");
+			throw new BaseException("식당을 생성할 수 없는 사용자", Constant.Code.STORE_ERROR, HttpStatus.FORBIDDEN);
 		}
 
 		StoreResponseDto responseDto = storeService.createStore(storeRequestDto);
@@ -95,9 +97,11 @@ public class StoreController {
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
 		@RequestBody StoreUpdateRequestDto storeRequestDto) {
 
-		if (storeService.findUserRole(userDetails.getUsername()) == Role.CUSTOMER) {
-			log.info("CUSTOMER인 사용자가 수정하려고 함");
-			throw new IllegalArgumentException("고객은 식당의 정보를 수정할 수 없습니다.");
+		Role role = storeService.findUserRole(userDetails.getUsername());
+
+		if (role == Role.CUSTOMER || role == Role.RIDER ) {
+			log.info("권한 없는 사용자가 수정하려고 함");
+			throw new BaseException("식당을 생성할 수 없는 사용자", Constant.Code.STORE_ERROR, HttpStatus.FORBIDDEN);
 		}
 
 		log.info("storeId: " + storeId);
@@ -116,9 +120,11 @@ public class StoreController {
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
 		@PathVariable UUID storeId){
 
-		if (storeService.findUserRole(userDetails.getUsername()) == Role.CUSTOMER) {
-			log.info("CUSTOMER인 사용자가 삭제하려고 함");
-			throw new IllegalArgumentException("고객은 식당을 삭제할 수 없습니다.");
+		Role role = storeService.findUserRole(userDetails.getUsername());
+
+		if (role == Role.CUSTOMER || role == Role.RIDER ) {
+			log.info("권한 없는 사용자가 수정하려고 함");
+			throw new BaseException("식당을 생성할 수 없는 사용자", Constant.Code.STORE_ERROR, HttpStatus.FORBIDDEN);
 		}
 
 		log.info("storeId: " + storeId);

--- a/src/main/java/com/sparta/first/project/eighteen/domain/stores/StoreController.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/stores/StoreController.java
@@ -1,6 +1,5 @@
 package com.sparta.first.project.eighteen.domain.stores;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -8,7 +7,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,9 +17,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.sparta.first.project.eighteen.common.dto.ApiResponse;
+import com.sparta.first.project.eighteen.common.security.UserDetailsImpl;
 import com.sparta.first.project.eighteen.domain.stores.dtos.StoreListResponseDto;
 import com.sparta.first.project.eighteen.domain.stores.dtos.StoreRequestDto;
 import com.sparta.first.project.eighteen.domain.stores.dtos.StoreResponseDto;
+import com.sparta.first.project.eighteen.domain.stores.dtos.StoreUpdateRequestDto;
 import com.sparta.first.project.eighteen.model.users.Role;
 
 import lombok.RequiredArgsConstructor;
@@ -43,13 +43,13 @@ public class StoreController {
 	 */
 	@PostMapping
 	public ResponseEntity<ApiResponse<StoreResponseDto>> createStore (
-		@AuthenticationPrincipal UserDetails userDetails,
+		@AuthenticationPrincipal UserDetailsImpl userDetails,
 		@RequestBody StoreRequestDto storeRequestDto) {
 
 		// userDetails 담긴 유저는 MASTER 이어야만 함
 		// MASTER 만 가게 생성 가능 (가게 생성 시 OWNER를 넣어주는 방식으로 진행)
-		if (storeService.findUserRole(userDetails.getUsername()) != Role.MANAGER) {
-			log.info("MANAGER가 아닌 사용자");
+		if (storeService.findUserRole(userDetails.getUsername()) != Role.MASTER) {
+			log.info("MASTER가 아닌 사용자");
 			throw new IllegalArgumentException("해당 사용자는 식당을 생성할 수 없습니다.");
 		}
 
@@ -63,6 +63,7 @@ public class StoreController {
 	 */
 	@GetMapping
 	public ResponseEntity<ApiResponse<Page<StoreListResponseDto>>> getStores(Pageable pageable){
+		log.info("getAllStoreList 요청 들어옴");
 		Page<StoreListResponseDto> responseDtos = storeService.getStores(pageable);
 		return ResponseEntity.ok(ApiResponse.ok("성공", responseDtos));
 	}
@@ -89,8 +90,8 @@ public class StoreController {
 	@PutMapping("/{storeId}")
 	public ResponseEntity<ApiResponse<StoreResponseDto>> updateStore (
 		@PathVariable UUID storeId,
-		@AuthenticationPrincipal UserDetails userDetails,
-		@RequestBody StoreRequestDto storeRequestDto) {
+		@AuthenticationPrincipal UserDetailsImpl userDetails,
+		@RequestBody StoreUpdateRequestDto storeRequestDto) {
 
 		if (storeService.findUserRole(userDetails.getUsername()) == Role.CUSTOMER) {
 			log.info("CUSTOMER인 사용자가 수정하려고 함");
@@ -110,7 +111,7 @@ public class StoreController {
 	 */
 	@DeleteMapping("/{storeId}")
 	public ResponseEntity<ApiResponse> deleteStore (
-		@AuthenticationPrincipal UserDetails userDetails,
+		@AuthenticationPrincipal UserDetailsImpl userDetails,
 		@PathVariable UUID storeId){
 
 		if (storeService.findUserRole(userDetails.getUsername()) == Role.CUSTOMER) {

--- a/src/main/java/com/sparta/first/project/eighteen/domain/stores/StoreRepository.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/stores/StoreRepository.java
@@ -2,9 +2,12 @@ package com.sparta.first.project.eighteen.domain.stores;
 
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.sparta.first.project.eighteen.model.stores.Stores;
 
-public interface StoreRepository extends JpaRepository<Stores, UUID> {
+public interface StoreRepository extends JpaRepository<Stores, UUID> /*, StoreRepositoryCustom */ {
+	Page<Stores> findByIsDeletedIsNull(Pageable pageable);
 }

--- a/src/main/java/com/sparta/first/project/eighteen/domain/stores/StoreRepository.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/stores/StoreRepository.java
@@ -2,12 +2,10 @@ package com.sparta.first.project.eighteen.domain.stores;
 
 import java.util.UUID;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.sparta.first.project.eighteen.model.stores.Stores;
 
-public interface StoreRepository extends JpaRepository<Stores, UUID> /*, StoreRepositoryCustom */ {
-	Page<Stores> findByIsDeletedIsNull(Pageable pageable);
+public interface StoreRepository extends JpaRepository<Stores, UUID>, StoreRepositoryCustom  {
+
 }

--- a/src/main/java/com/sparta/first/project/eighteen/domain/stores/StoreRepositoryCustom.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/stores/StoreRepositoryCustom.java
@@ -1,12 +1,18 @@
 package com.sparta.first.project.eighteen.domain.stores;
 
+import java.util.UUID;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import com.sparta.first.project.eighteen.domain.stores.dtos.StoreListResponseDto;
+import com.sparta.first.project.eighteen.domain.stores.dtos.StoreResponseDto;
 import com.sparta.first.project.eighteen.domain.stores.dtos.StoreSearchDto;
 import com.sparta.first.project.eighteen.model.users.Role;
 
 public interface StoreRepositoryCustom {
 	Page<StoreListResponseDto> searchStores(StoreSearchDto searchDto, Pageable pageable, Role role);
+
+	StoreResponseDto getOneStoreById(UUID storeId);
+
 }

--- a/src/main/java/com/sparta/first/project/eighteen/domain/stores/StoreRepositoryCustom.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/stores/StoreRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.sparta.first.project.eighteen.domain.stores;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.sparta.first.project.eighteen.domain.stores.dtos.StoreListResponseDto;
+import com.sparta.first.project.eighteen.domain.stores.dtos.StoreSearchDto;
+import com.sparta.first.project.eighteen.model.users.Role;
+
+public interface StoreRepositoryCustom {
+	Page<StoreListResponseDto> searchStores(StoreSearchDto searchDto, Pageable pageable, Role role);
+}

--- a/src/main/java/com/sparta/first/project/eighteen/domain/stores/StoreRepositoryCustomImpl.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/stores/StoreRepositoryCustomImpl.java
@@ -229,13 +229,11 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
 	 * @return : 권한에 따른 결과 리턴
 	 */
 	private BooleanExpression confirmDeletedByRole(Role role) {
-		if (role.equals(Role.CUSTOMER)) {
-			log.info("고객의 조회");
-			// null or false인 경우만 반환 (삭제된 식당은 보이지 않음)
+		if (role.equals(Role.CUSTOMER) || role.equals(Role.RIDER) || role.equals(Role.OWNER)) {
+			log.info("고객, 라이더, 식당 주인의 조회 - 삭제된 식당은 조회 불가");
 			return stores.isDeleted.eq(false);
 		} else {
-			log.info("고객이 아닌 사람의 조회");
-			// 아무 조건도 추가하지 않음으로써 모든 데이터 반환
+			log.info("마스터, 매니저의 조회");
 			return null; 
 		}
 	}
@@ -248,9 +246,9 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
 	private List<OrderSpecifier<?>> getAllOrderSpecifiers(Pageable pageable) {
 		List<OrderSpecifier<?>> orders = new ArrayList<>();
 
-		// 정렬 기준이 존재한다면
-		// pageable -> 클라이언트가 요청한 페이지 정보를 담고 있는 객체, 정렬 정보도 포함
-		// sort -> 내부적으로 여러 개의 sort를 가짐
+		/* 정렬 기준이 존재한다면
+		   pageable -> 클라이언트가 요청한 페이지 정보를 담고 있는 객체, 정렬 정보도 포함
+		   sort -> 내부적으로 여러 개의 sort를 가짐 */
 		if (pageable.getSort() != null) {
 			log.info("정렬 조건이 있어요");
 			// 정렬 정보 한 개씩 돌림

--- a/src/main/java/com/sparta/first/project/eighteen/domain/stores/StoreRepositoryCustomImpl.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/stores/StoreRepositoryCustomImpl.java
@@ -1,0 +1,202 @@
+package com.sparta.first.project.eighteen.domain.stores;
+
+import static com.sparta.first.project.eighteen.model.stores.QStores.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import com.querydsl.core.QueryResults;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.first.project.eighteen.domain.reviews.ReviewRepository;
+import com.sparta.first.project.eighteen.domain.stores.dtos.StoreListResponseDto;
+import com.sparta.first.project.eighteen.domain.stores.dtos.StoreSearchDto;
+import com.sparta.first.project.eighteen.model.stores.QStores;
+import com.sparta.first.project.eighteen.model.stores.StoreCategory;
+import com.sparta.first.project.eighteen.model.stores.Stores;
+import com.sparta.first.project.eighteen.model.users.Role;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+	private final ReviewRepository reviewRepository;
+
+	/**
+	 *
+	 * @param searchDto
+	 * @param pageable
+	 * @param role
+	 * @return
+	 */
+	@Override
+	public Page<StoreListResponseDto> searchStores
+		(StoreSearchDto searchDto, Pageable pageable, Role role) {
+
+		List<OrderSpecifier<?>> orders = getAllOrderSpecifiers(pageable);
+		log.info(searchDto.getStoreRegion());
+
+		QueryResults<Stores> results = queryFactory
+			.selectFrom(stores)
+			.where(
+				confirmDeletedByRole(role) ,
+				storeNameContains(searchDto.getStoreName()),
+				storeRegion(searchDto.getStoreRegion()),
+				storeCategory(searchDto.getStoreCategory()),
+				deliveryPriceBetween(searchDto.getMinDeliveryPrice(), searchDto.getMaxDeliveryPrice())
+			)
+			.orderBy(orders.toArray(new OrderSpecifier[0]))
+			.offset(pageable.getOffset())
+			.limit(getPageSize(pageable.getPageSize(), pageable.getOffset()))
+			.fetchResults();
+
+		List<StoreListResponseDto> contents = invertToResponseDto(results);
+		long total = results.getTotal();
+
+		return new PageImpl<>(contents, pageable, total);
+	}
+
+	/**
+	 * 리스트로 만들어 필터링
+	 * @param results : 필터링할 쿼리 결과문
+	 */
+	private List<StoreListResponseDto> invertToResponseDto (QueryResults<Stores> results) {
+		List<StoreListResponseDto> list = new ArrayList<>();
+
+		// StoreRating을 어떻게 넣을지 ?
+		for (Stores s : results.getResults()) {
+			list.add(StoreListResponseDto.fromEntity(s));
+		}
+
+		return list;
+	}
+
+	/**
+	 * 페이지에 가져올 데이터의 개수
+	 * @param pageSize : 페이지에 가져올 데이터 개수
+	 * @param offset : 페이지 수
+	 * @return : 0페이지면 pagesize, 1페이지부터는 10개 반환
+	 */
+	private long getPageSize(long pageSize, long offset) {
+		if (offset == 0) {
+			return pageSize;
+		} else {
+			return 10;
+		}
+	}
+	
+	/**
+	 * 식당 이름을 검색하는 경우
+	 * @param storeName : 식당명 검색어
+	 * @return : 검색어 포함 여부 반환
+	 */
+	private BooleanExpression storeNameContains(String storeName) {
+		return storeName != null ? stores.storeName.contains(storeName) : null;
+	}
+
+	/**
+	 * 식당 지역을 검색하는 경우
+	 * @param storeRegion : 식당 지역
+	 * @return : 지역과 일치하는지 여부 반환
+	 */
+	private BooleanExpression storeRegion(String storeRegion) {
+		return storeRegion != null ? stores.storeRegion.eq(storeRegion) : null;
+	}
+
+	/**
+	 * 식당 카테고리를 검색하는 경우
+	 * @param storeCategory : 검색할 식당 카테고리
+	 * @return : 카테고리와 일치하는지 여부 반환
+	 */
+	private BooleanExpression storeCategory(StoreCategory storeCategory) {
+		return storeCategory != null ? stores.storeCategory.eq(storeCategory) : null;
+	}
+
+	/**
+	 * 식당 배달팁의 최소, 최대값을 검색하는 경우
+	 * @param minDeliveryPrice : 배달팁 최솟값
+	 * @param maxDeliveryPrice : 배달팁 최댓값
+	 * @return : 최소, 최대 범위 조건이 있는지 여부 반환
+	 */
+	private BooleanExpression deliveryPriceBetween(Integer minDeliveryPrice, Integer maxDeliveryPrice) {
+		if ((minDeliveryPrice != null) && (maxDeliveryPrice != null)) {
+			return stores.storeDeliveryPrice.between(minDeliveryPrice, maxDeliveryPrice);
+		} else if (minDeliveryPrice != null) {
+			return stores.storeDeliveryPrice.goe(minDeliveryPrice);
+		} else if (maxDeliveryPrice != null) {
+			return stores.storeDeliveryPrice.loe(maxDeliveryPrice);
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * 권한에 따른 식당 리스트 확인
+	 * @param role : 사용자 권한 확인
+	 * @return : 권한에 따른 결과 리턴
+	 */
+	private BooleanExpression confirmDeletedByRole(Role role) {
+		if (role.equals(Role.CUSTOMER)) {
+			log.info("고객의 조회");
+			// null or false인 경우만 반환 (삭제된 식당은 보이지 않음)
+			return stores.isDeleted.isNull().or(stores.isDeleted.eq(false)); 
+		} else {
+			log.info("고객이 아닌 사람의 조회");
+			// 아무 조건도 추가하지 않음으로써 모든 데이터 반환
+			return null; 
+		}
+	}
+
+	/**
+	 * 정렬 조건을 기반으로 OrderSpecifier 리스트 생성
+	 * @param pageable : 정렬 조건을 포함한 Pageable 객체
+	 * @return : QueryDSL에서 사용할 OrderSpecifier 리스트
+	 */
+	private List<OrderSpecifier<?>> getAllOrderSpecifiers(Pageable pageable) {
+		List<OrderSpecifier<?>> orders = new ArrayList<>();
+
+		// 정렬 기준이 존재한다면
+		// pageable -> 클라이언트가 요청한 페이지 정보를 담고 있는 객체, 정렬 정보도 포함
+		// sort -> 내부적으로 여러 개의 sort를 가짐
+		if (pageable.getSort() != null) {
+			// 정렬 정보 한 개씩 돌림
+			for (Sort.Order sortOrder : pageable.getSort()) {
+				orderSorting(sortOrder, orders);
+			}
+		}
+
+		return orders;
+	}
+
+	/**
+	 * Sort.Order기반의 정렬 조건을 정렬 리스트에 추가
+	 * @param sortOrder : 정렬 정보(오름차순/내림차순)
+	 * @param orders : 정렬 조건을 저장할 QueryDSL 리스트
+	 */
+	private void orderSorting(Sort.Order sortOrder, List<OrderSpecifier<?>> orders) {
+		log.info("정렬 기준: " + sortOrder.getProperty() + " / " + "오름차순-내림차순: " + sortOrder.getDirection());
+		com.querydsl.core.types.Order direction = sortOrder.isAscending() ? com.querydsl.core.types.Order.ASC : com.querydsl.core.types.Order.DESC;
+
+		// 정렬 기준의 경우에 따라
+		switch (sortOrder.getProperty()) {
+			case "createdAt" :
+				orders.add(new OrderSpecifier<>(direction, QStores.stores.createdAt));
+				break;
+			case "modifiedAt" :
+				orders.add(new OrderSpecifier<>(direction, QStores.stores.modifiedAt));
+				break;
+			default :
+				break;
+		}
+	}
+}

--- a/src/main/java/com/sparta/first/project/eighteen/domain/stores/StoreService.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/stores/StoreService.java
@@ -2,8 +2,10 @@ package com.sparta.first.project.eighteen.domain.stores;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,8 +15,10 @@ import com.sparta.first.project.eighteen.domain.reviews.ReviewRepository;
 import com.sparta.first.project.eighteen.domain.stores.dtos.StoreListResponseDto;
 import com.sparta.first.project.eighteen.domain.stores.dtos.StoreRequestDto;
 import com.sparta.first.project.eighteen.domain.stores.dtos.StoreResponseDto;
+import com.sparta.first.project.eighteen.domain.stores.dtos.StoreUpdateRequestDto;
 import com.sparta.first.project.eighteen.domain.users.UserRepository;
 import com.sparta.first.project.eighteen.model.stores.Stores;
+import com.sparta.first.project.eighteen.model.reviews.Reviews;
 import com.sparta.first.project.eighteen.model.users.Role;
 import com.sparta.first.project.eighteen.model.users.Users;
 
@@ -51,11 +55,15 @@ public class StoreService {
 	 * @return : 조회한 식당의 정보들을 반환
 	 */
 	public Page<StoreListResponseDto> getStores(Pageable pageable) {
-		Page<StoreListResponseDto> stores = storeRepository.findByIsDeletedIsNull(pageable)
-			.map(StoreListResponseDto::fromEntity);
-		
-		// QueryDSL 적용 필요
-		return stores;
+		log.info("Service로 getAllStore 요청 넘어옴");
+		Page<Stores> storePage = storeRepository.findAll(pageable);
+
+		List<StoreListResponseDto> filteredStores = storePage.getContent().stream()
+			.filter(s -> !s.getIsDeleted())
+			.map(StoreListResponseDto::fromEntity)
+			.toList();
+
+		return new PageImpl<>(filteredStores, pageable, filteredStores.size());
 	}
 
 	/**
@@ -78,7 +86,7 @@ public class StoreService {
 	 * @return : 수정을 완료한 식당 정보
 	 */
 	@Transactional
-	public StoreResponseDto updateStore(UUID storeId, String username, StoreRequestDto storeRequestDto) {
+	public StoreResponseDto updateStore(UUID storeId, String username, StoreUpdateRequestDto storeRequestDto) {
 		// 유저의 권한이 OWNER 라면, store에 저장된 유저와 일치하는지 확인해야 함
 		Users user = findStoreOwner(username);
 		Stores store = findStore(storeId);
@@ -91,12 +99,13 @@ public class StoreService {
 		}
 
 		// 식당 내용 update
-		Stores updatingStore = storeRequestDto.updateEntity(store, user);
-		Stores updatedStore = storeRepository.save(updatingStore);
+		Stores updateStore = storeRequestDto.toEntity();
+		store.updateStore(updateStore);
 
-		int storeReviewCnt = getStoreReviewCnt(updatedStore);
-		double storeRating = getStoreReviewSum(updatedStore, storeReviewCnt);
-		return StoreResponseDto.fromEntityReview(updatedStore, storeReviewCnt, storeRating);
+		int storeReviewCnt = getStoreReviewCnt(store);
+		double storeRating = getStoreReviewSum(store, storeReviewCnt);
+
+		return StoreResponseDto.fromEntityReview(store, storeReviewCnt, storeRating);
 	}
 
 	/**
@@ -139,9 +148,13 @@ public class StoreService {
 	 * @return : 식당의 리뷰 평점
 	 */
 	private double getStoreReviewSum(Stores store, int storeReviewCnt) {
-		List<Integer> list = reviewRepository.findReviewRatingByStoreId(store);
+		List<Integer> list = reviewRepository.findReviewRatingByStoreId(store)
+			.stream()
+			.map(Reviews::getReviewRating)
+			.collect(Collectors.toList());
+
 		if (list.isEmpty() || list == null || storeReviewCnt == 0) {
-			throw new IllegalArgumentException("잘못된 계산입니다.");
+			return 0;
 		}
 		
 		int sum = 0;
@@ -158,7 +171,7 @@ public class StoreService {
 	 * @return : 조회한 식당
 	 */
 	public Stores findStore(UUID storeId) {
-		return storeRepository.findById(storeId).filter(s -> s.getIsDeleted() == null)
+		return storeRepository.findById(storeId).filter(s -> s.getIsDeleted() == false)
 			.orElseThrow(() -> new IllegalArgumentException("존재하지 않거나 삭제된 식당"));
 	}
 

--- a/src/main/java/com/sparta/first/project/eighteen/domain/stores/StoreService.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/stores/StoreService.java
@@ -1,0 +1,184 @@
+package com.sparta.first.project.eighteen.domain.stores;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sparta.first.project.eighteen.common.dto.ApiResponse;
+import com.sparta.first.project.eighteen.domain.reviews.ReviewRepository;
+import com.sparta.first.project.eighteen.domain.stores.dtos.StoreListResponseDto;
+import com.sparta.first.project.eighteen.domain.stores.dtos.StoreRequestDto;
+import com.sparta.first.project.eighteen.domain.stores.dtos.StoreResponseDto;
+import com.sparta.first.project.eighteen.domain.users.UserRepository;
+import com.sparta.first.project.eighteen.model.stores.Stores;
+import com.sparta.first.project.eighteen.model.users.Role;
+import com.sparta.first.project.eighteen.model.users.Users;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StoreService {
+
+	private final StoreRepository storeRepository;
+	private final UserRepository userRepository;
+	private final ReviewRepository reviewRepository;
+
+	/**
+	 * 식당 생성
+	 * @param storeRequestDto : 생성할 식당의 내용
+	 * @return : 생성 완료한 식당의 정보
+	 */
+	public StoreResponseDto createStore(StoreRequestDto storeRequestDto) {
+		// 식당을 만들 유저 검색
+		Users storeOwner = findStoreOwner(storeRequestDto.getStoreOwnerName());
+		// 식당 생성 및 저장
+		Stores store = storeRequestDto.toEntity(storeOwner);
+		Stores newStore = storeRepository.save(store);
+		// 식당 반환
+		return StoreResponseDto.fromEntity(newStore);
+	}
+
+	/**
+	 * 식당 전체 조회
+	 * @param pageable : 조회할 정보들
+	 * @return : 조회한 식당의 정보들을 반환
+	 */
+	public Page<StoreListResponseDto> getStores(Pageable pageable) {
+		Page<StoreListResponseDto> stores = storeRepository.findByIsDeletedIsNull(pageable)
+			.map(StoreListResponseDto::fromEntity);
+		
+		// QueryDSL 적용 필요
+		return stores;
+	}
+
+	/**
+	 * 식당 단건 조회
+	 * @param storeId : 조회할 식당의 ID
+	 * @return : 조회한 식당의 정보
+	 */
+	public StoreResponseDto getOneStore(UUID storeId) {
+		Stores store = findStore(storeId);
+		int storeReviewCnt = getStoreReviewCnt(store);
+		double storeRating = getStoreReviewSum(store, storeReviewCnt);
+		return StoreResponseDto.fromEntityReview(store, storeReviewCnt, storeRating);
+	}
+
+	/**
+	 * 식당 수정
+	 * @param storeId : 수정할 식당의 ID
+	 * @param username : 식당 내용을 수정하려는 사용자명
+	 * @param storeRequestDto : 수정하려는 식당 내용
+	 * @return : 수정을 완료한 식당 정보
+	 */
+	@Transactional
+	public StoreResponseDto updateStore(UUID storeId, String username, StoreRequestDto storeRequestDto) {
+		// 유저의 권한이 OWNER 라면, store에 저장된 유저와 일치하는지 확인해야 함
+		Users user = findStoreOwner(username);
+		Stores store = findStore(storeId);
+
+		if (user.getRole() == Role.OWNER &&
+			!user.getUserId().equals(store.getUserId().getUserId())) {
+			log.info(user.getUserId().toString());
+			log.info(store.getUserId().getUserId().toString());
+			throw new IllegalArgumentException("해당 식당의 주인이 아닙니다.");
+		}
+
+		// 식당 내용 update
+		Stores updatingStore = storeRequestDto.updateEntity(store, user);
+		Stores updatedStore = storeRepository.save(updatingStore);
+
+		int storeReviewCnt = getStoreReviewCnt(updatedStore);
+		double storeRating = getStoreReviewSum(updatedStore, storeReviewCnt);
+		return StoreResponseDto.fromEntityReview(updatedStore, storeReviewCnt, storeRating);
+	}
+
+	/**
+	 * 식당 삭제
+	 * @param storeId : 삭제할 식당의 ID
+	 * @param username : 식당 내용을 삭제하려는 사용자명
+	 * @return : 삭제 상황
+	 */
+	@Transactional
+	public ApiResponse deleteStore(UUID storeId, String username) {
+		// 유저의 권한이 OWNER 라면, store에 저장된 유저와 일치하는지 확인해야 함
+		Users user = findStoreOwner(username);
+		Stores store = findStore(storeId);
+
+		if (user.getRole() == Role.OWNER &&
+			!user.getUserId().equals(store.getUserId().getUserId())) {
+			throw new IllegalArgumentException("해당 식당의 주인이 아닙니다.");
+		}
+
+		// 식당 삭제
+		store.delete(true, user.getUserId().toString());
+		storeRepository.save(store);
+		log.info("삭제 여부 : " + store.getIsDeleted());
+		return ApiResponse.ok("삭제 성공", "식당명 : " + store.getStoreName());
+	}
+
+	/**
+	 * 식당에 존재하는 리뷰의 개수
+	 * @param storeId : 리뷰를 가져올 식당의 ID
+	 * @return : 식당에 존재하는 리뷰 개수
+	 */
+	public int getStoreReviewCnt(Stores storeId) {
+		return reviewRepository.countByStoreId(storeId);
+	}
+
+	/**
+	 * 식당 리뷰 평점 계산
+	 * @param store : 평점을 계산할 식당
+	 * @param storeReviewCnt : 식당의 리뷰 개수
+	 * @return : 식당의 리뷰 평점
+	 */
+	private double getStoreReviewSum(Stores store, int storeReviewCnt) {
+		List<Integer> list = reviewRepository.findReviewRatingByStoreId(store);
+		if (list.isEmpty() || list == null || storeReviewCnt == 0) {
+			throw new IllegalArgumentException("잘못된 계산입니다.");
+		}
+		
+		int sum = 0;
+		for (Integer i : list) {
+			sum += i;
+		}
+
+		return sum / storeReviewCnt;
+	}
+
+	/**
+	 * 식당 탐색
+	 * @param storeId : 조회할 식당의 ID
+	 * @return : 조회한 식당
+	 */
+	public Stores findStore(UUID storeId) {
+		return storeRepository.findById(storeId).filter(s -> s.getIsDeleted() == null)
+			.orElseThrow(() -> new IllegalArgumentException("존재하지 않거나 삭제된 식당"));
+	}
+
+	/**
+	 * 식당 주인 탐색
+	 * @param username : 식당을 차릴 사용자명
+	 * @return : 조회한 사용자
+	 */
+	public Users findStoreOwner(String username) {
+		return userRepository.findByUsername(username).orElseThrow(
+			() -> new IllegalArgumentException("존재하지 않는 유저"));
+	}
+
+	/**
+	 * 사용자 권한 탐색
+	 * @param username : 권한을 보려는 사용자명
+	 * @return : 조회한 사용자의 권한
+	 */
+	public Role findUserRole(String username) {
+		return userRepository.findByUsername(username).orElseThrow(
+			() -> new IllegalArgumentException("존재하지 않는 유저")).getRole();
+	}
+}

--- a/src/main/java/com/sparta/first/project/eighteen/domain/stores/StoreService.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/stores/StoreService.java
@@ -59,7 +59,8 @@ public class StoreService {
 	 */
 	public PagedModel<StoreListResponseDto> getStores(String username, StoreSearchDto searchDto) {
 		log.info("Service로 getStores 요청 넘어옴");
-		Pageable pageable = PageRequest.of(searchDto.getPage(), searchDto.getSize());
+		Pageable pageable = PageRequest.of(searchDto.getPage(), searchDto.getSize(),
+			searchDto.getDirection(), searchDto.getSortBy());
 
 		Role role = Role.CUSTOMER;
 		if (username != null) {
@@ -77,11 +78,11 @@ public class StoreService {
 	 * @param storeId : 조회할 식당의 ID
 	 * @return : 조회한 식당의 정보
 	 */
+	@Transactional(readOnly = true)
 	public StoreResponseDto getOneStore(UUID storeId) {
+		// 커스텀 만들어서 사용할까 ?
 		Stores store = findStore(storeId);
-		int storeReviewCnt = getStoreReviewCnt(store);
-		double storeRating = getStoreReviewSum(store, storeReviewCnt);
-		return StoreResponseDto.fromEntityReview(store, storeReviewCnt, storeRating);
+		return storeRepository.getOneStoreById(storeId);
 	}
 
 	/**

--- a/src/main/java/com/sparta/first/project/eighteen/domain/stores/dtos/StoreListResponseDto.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/stores/dtos/StoreListResponseDto.java
@@ -34,14 +34,6 @@ public class StoreListResponseDto {
 	// 식당 배달팁
 	private int storeDeliveryPrice;
 
-	// 테스트를 위한 임시 생성자
-	public StoreListResponseDto(StoreRequestDto storeRequestDto) {
-		this.id = "1";
-		this.storeName = "한식당";
-		this.storeRegion = "서울 광화문";
-		this.storeRating = 4.3;
-	}
-
 	public static StoreListResponseDto fromEntity(Stores store) {
 		return StoreListResponseDto.builder()
 			.id(store.getId().toString())

--- a/src/main/java/com/sparta/first/project/eighteen/domain/stores/dtos/StoreRequestDto.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/stores/dtos/StoreRequestDto.java
@@ -4,13 +4,17 @@ import com.sparta.first.project.eighteen.model.stores.StoreCategory;
 import com.sparta.first.project.eighteen.model.stores.Stores;
 import com.sparta.first.project.eighteen.model.users.Users;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class StoreRequestDto {
 
 	// 식당명
@@ -24,6 +28,9 @@ public class StoreRequestDto {
 
 	// 식당 카테고리
 	private StoreCategory storeCategory;
+
+	// 식당 주인
+	private String storeOwnerName;
 
 	// 식당 배달팁
 	private int storeDeliveryPrice;
@@ -39,6 +46,19 @@ public class StoreRequestDto {
 			.storeImgUrl(this.storeImgUrl)
 			.storeDeliveryPrice(this.storeDeliveryPrice)
 			.storeCategory(this.storeCategory)
+			.userId(user)
+			.build();
+	}
+
+	public Stores updateEntity(Stores store, Users user) {
+		return Stores.builder()
+			.id(store.getId())
+			.storeName(this.storeName != null ? this.storeName : store.getStoreName())
+			.storeDesc(this.storeDesc != null ? this.storeDesc : store.getStoreDesc())
+			.storeRegion(this.storeRegion != null ? this.storeRegion : store.getStoreRegion())
+			.storeImgUrl(this.storeImgUrl != null ? this.storeImgUrl : store.getStoreImgUrl())
+			.storeDeliveryPrice(this.storeDeliveryPrice)
+			.storeCategory(this.storeCategory != null ? this.storeCategory : store.getStoreCategory())
 			.userId(user)
 			.build();
 	}

--- a/src/main/java/com/sparta/first/project/eighteen/domain/stores/dtos/StoreRequestDto.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/stores/dtos/StoreRequestDto.java
@@ -50,17 +50,4 @@ public class StoreRequestDto {
 			.build();
 	}
 
-	public Stores updateEntity(Stores store, Users user) {
-		return Stores.builder()
-			.id(store.getId())
-			.storeName(this.storeName != null ? this.storeName : store.getStoreName())
-			.storeDesc(this.storeDesc != null ? this.storeDesc : store.getStoreDesc())
-			.storeRegion(this.storeRegion != null ? this.storeRegion : store.getStoreRegion())
-			.storeImgUrl(this.storeImgUrl != null ? this.storeImgUrl : store.getStoreImgUrl())
-			.storeDeliveryPrice(this.storeDeliveryPrice)
-			.storeCategory(this.storeCategory != null ? this.storeCategory : store.getStoreCategory())
-			.userId(user)
-			.build();
-	}
-
 }

--- a/src/main/java/com/sparta/first/project/eighteen/domain/stores/dtos/StoreResponseDto.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/stores/dtos/StoreResponseDto.java
@@ -41,6 +41,9 @@ public class StoreResponseDto {
 	// 식당 리뷰 개수
 	private int storeReviewCnt;
 
+	// 식당 이미지
+	private String storeImgUrl;
+
 	// 식당 배달 팁
 	private int storeDeliveryPrice;
 

--- a/src/main/java/com/sparta/first/project/eighteen/domain/stores/dtos/StoreResponseDto.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/stores/dtos/StoreResponseDto.java
@@ -41,19 +41,27 @@ public class StoreResponseDto {
 	// 식당 리뷰 개수
 	private int storeReviewCnt;
 
-	// 테스트를 위한 임시 생성자
-	public StoreResponseDto(StoreRequestDto storeRequestDto) {
-		this.id = "1";
-		this.userName = "김사장";
-		this.storeName = storeRequestDto.getStoreName();
-		this.storeDesc = storeRequestDto.getStoreDesc();
-		this.storeRegion = storeRequestDto.getStoreRegion();
-		this.storeCategory = storeRequestDto.getStoreCategory();
-		this.storeRating = 4.3;
-		this.storeReviewCnt = 100;
-	}
+	// 식당 배달 팁
+	private int storeDeliveryPrice;
+
+	// 식당 생성일자
+	private String createdAt;
 
 	public static StoreResponseDto fromEntity(Stores stores) {
+		return StoreResponseDto.builder()
+			// .id(stores.getId().toString())
+			.userName(stores.getUserId().getUsername())
+			.storeName(stores.getStoreName())
+			.storeDesc(stores.getStoreDesc())
+			.storeRegion(stores.getStoreRegion())
+			.storeCategory(stores.getStoreCategory())
+			.storeRating(stores.getStoreRating())
+			.storeDeliveryPrice(stores.getStoreDeliveryPrice())
+			// .createdAt(stores.getCreatedAt().toString())
+			.build();
+	}
+
+	public static StoreResponseDto fromEntityReview(Stores stores, int storeReviewCnt, double storeRating) {
 		return StoreResponseDto.builder()
 			.id(stores.getId().toString())
 			.userName(stores.getUserId().getUsername())
@@ -62,6 +70,10 @@ public class StoreResponseDto {
 			.storeRegion(stores.getStoreRegion())
 			.storeCategory(stores.getStoreCategory())
 			.storeRating(stores.getStoreRating())
+			.storeDeliveryPrice(stores.getStoreDeliveryPrice())
+			.storeReviewCnt(storeReviewCnt)
+			.storeRating(storeRating)
+			.createdAt(stores.getCreatedAt().toString())
 			.build();
 	}
 

--- a/src/main/java/com/sparta/first/project/eighteen/domain/stores/dtos/StoreResponseDto.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/stores/dtos/StoreResponseDto.java
@@ -39,7 +39,7 @@ public class StoreResponseDto {
 	private double storeRating;
 
 	// 식당 리뷰 개수
-	private int storeReviewCnt;
+	private long storeReviewCnt;
 
 	// 식당 이미지
 	private String storeImgUrl;

--- a/src/main/java/com/sparta/first/project/eighteen/domain/stores/dtos/StoreSearchDto.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/stores/dtos/StoreSearchDto.java
@@ -32,6 +32,12 @@ public class StoreSearchDto {
 	// 식당 최대 배달팁
 	private int maxDeliveryPrice;
 
+	// 식당 최소 리뷰 평점
+	private int minReviewRating;
+
+	// 식당 최대 리뷰 평점
+	private int maxReviewRating;
+
 	// 가져올 페이지 수
 	@JsonSetter(nulls = Nulls.SKIP)
 	private int page = 0;
@@ -42,7 +48,7 @@ public class StoreSearchDto {
 
 	// 가져올 정렬 기준
 	@JsonSetter(nulls = Nulls.SKIP)
-	private String sortBy;
+	private String sortBy = "createdAt";
 
 	@JsonSetter(nulls = Nulls.SKIP)
 	private Sort.Direction direction = Sort.Direction.ASC;

--- a/src/main/java/com/sparta/first/project/eighteen/domain/stores/dtos/StoreSearchDto.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/stores/dtos/StoreSearchDto.java
@@ -2,11 +2,17 @@ package com.sparta.first.project.eighteen.domain.stores.dtos;
 
 import org.springframework.data.domain.Pageable;
 
+import com.sparta.first.project.eighteen.model.stores.StoreCategory;
+
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class StoreSearchDto {
 
 	// 식당명
@@ -16,9 +22,12 @@ public class StoreSearchDto {
 	private String storeRegion;
 
 	// 식당 카테고리
-	private String storeCategory;
+	private StoreCategory storeCategory;
 
-	// pageable
-	private Pageable pageable;
+	// 식당 최소 배달팁
+	private int minDeliveryPrice;
+
+	// 식당 최대 배달팁
+	private int maxDeliveryPrice;
 
 }

--- a/src/main/java/com/sparta/first/project/eighteen/domain/stores/dtos/StoreSearchDto.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/stores/dtos/StoreSearchDto.java
@@ -1,7 +1,9 @@
 package com.sparta.first.project.eighteen.domain.stores.dtos;
 
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.sparta.first.project.eighteen.model.stores.StoreCategory;
 
 import lombok.AllArgsConstructor;
@@ -29,5 +31,20 @@ public class StoreSearchDto {
 
 	// 식당 최대 배달팁
 	private int maxDeliveryPrice;
+
+	// 가져올 페이지 수
+	@JsonSetter(nulls = Nulls.SKIP)
+	private int page = 0;
+
+	// 페이지에 가져올 데이터 크기
+	@JsonSetter(nulls = Nulls.SKIP)
+	private int size = 10;
+
+	// 가져올 정렬 기준
+	@JsonSetter(nulls = Nulls.SKIP)
+	private String sortBy;
+
+	@JsonSetter(nulls = Nulls.SKIP)
+	private Sort.Direction direction = Sort.Direction.ASC;
 
 }

--- a/src/main/java/com/sparta/first/project/eighteen/domain/stores/dtos/StoreUpdateRequestDto.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/stores/dtos/StoreUpdateRequestDto.java
@@ -1,0 +1,47 @@
+package com.sparta.first.project.eighteen.domain.stores.dtos;
+
+import com.sparta.first.project.eighteen.model.stores.StoreCategory;
+import com.sparta.first.project.eighteen.model.stores.Stores;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StoreUpdateRequestDto {
+
+	// 식당명
+	private String storeName;
+
+	// 식당 소개
+	private String storeDesc;
+
+	// 식당 지역
+	private String storeRegion;
+
+	// 식당 카테고리
+	private StoreCategory storeCategory;
+
+	// 식당 배달팁
+	private int storeDeliveryPrice;
+
+	// 식당 이미지
+	private String storeImgUrl;
+
+	public Stores toEntity() {
+		return Stores.builder()
+			.storeName(this.storeName)
+			.storeDesc(this.storeDesc)
+			.storeRegion(this.storeRegion)
+			.storeImgUrl(this.storeImgUrl)
+			.storeDeliveryPrice(this.storeDeliveryPrice)
+			.storeCategory(this.storeCategory)
+			.build();
+	}
+}

--- a/src/main/java/com/sparta/first/project/eighteen/model/stores/Stores.java
+++ b/src/main/java/com/sparta/first/project/eighteen/model/stores/Stores.java
@@ -1,5 +1,6 @@
 package com.sparta.first.project.eighteen.model.stores;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import com.sparta.first.project.eighteen.common.BaseEntity;
@@ -9,6 +10,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -64,7 +66,20 @@ public class Stores extends BaseEntity {
 	private double storeRating;
 
 	// 회원 ID (식당 주인)
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", referencedColumnName = "id")
 	private Users userId;
+
+	/**
+	 * 식당 내용 수정
+	 * @param updateStore : 수정할 식당의 내용
+	 */
+	public void updateStore(Stores updateStore) {
+		Optional.ofNullable(updateStore.getStoreName()).ifPresent(storeName -> this.storeName = storeName);
+		Optional.ofNullable(updateStore.getStoreDesc()).ifPresent(storeDesc -> this.storeDesc = storeDesc);
+		Optional.ofNullable(updateStore.getStoreRegion()).ifPresent(storeRegion -> this.storeRegion = storeRegion);
+		Optional.ofNullable(updateStore.getStoreCategory()).ifPresent(storeCategory -> this.storeCategory = storeCategory);
+		Optional.ofNullable(updateStore.getStoreDeliveryPrice()).ifPresent(storeDeliveryPrice -> this.storeDeliveryPrice = storeDeliveryPrice);
+		Optional.ofNullable(updateStore.getStoreImgUrl()).ifPresent(storeImgUrl -> this.storeImgUrl = storeImgUrl);
+	}
 }


### PR DESCRIPTION
## 관련 이슈
- #50 

## 변경 타입
- [X] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
    - Store Service 없이 개발

- **to-be**
    - Store Service 개발 후 로직 수정
    - Custom Repository 추가

## 코멘트
- 현재 create, update, getone 시 store responsdto 가져오는 방식이 다릅니다.
    1. create - responseDto.toEntity() : 리뷰 평점 및 리뷰 개수 계산 작업이 들어가지 않는 엔티티
    2. update - responsDto.fromEntityReview() : dto로 변환할 때 service 단에서 리뷰 평점과 리뷰 개수를 계산(메서드)하여 넣어줌
    3. getone - customrepo에서 반환 : repository에서 찾아서 dto로 변환할 때 queryDsl로 계산하여 넣어줌
    4. 추가 - review custom repo에 있는 메서드 사용 (리뷰 평점 계산, 리뷰 개수 계산 메서드)
    
    네 가지 방법 중에 하나로 통일할 예정인데, review service쪽 까지 통합한 이후에 수정해보려고 합니다.
    어떤 방법이 제일 나아보이시는지 의견 있으시다면 코멘트 부탁드립니다!