### PR TITLE
Feat/69 order delete and status update

### DIFF
--- a/src/main/java/com/sparta/first/project/eighteen/domain/orders/OrderController.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/orders/OrderController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.sparta.first.project.eighteen.common.dto.ApiResponse;
@@ -122,9 +123,9 @@ public class OrderController {
 	 * @return  : 주문 정보
 	 */
 	@PreAuthorize("hasAnyRole('OWNER','RIDER')")
-	@PatchMapping("/{id}/{status}")
+	@PatchMapping("/{id}")
 	public ResponseEntity<ApiResponse<OrderResponseDto>> updateOrderStatus(@PathVariable String id,
-		@PathVariable OrderStatus status) {
+		@RequestParam OrderStatus status) {
 		OrderResponseDto responseDto = orderService.updateOrderStatus(id, status);
 		return ResponseEntity.ok(ApiResponse.ok("주문 상태가 변경되었습니다.", responseDto));
 	}

--- a/src/main/java/com/sparta/first/project/eighteen/domain/orders/OrderController.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/orders/OrderController.java
@@ -102,8 +102,9 @@ public class OrderController {
 	 * @return  :
 	 */
 	@DeleteMapping("/{id}")
-	public ResponseEntity<ApiResponse<Void>> deleteOrder(@PathVariable String id) {
-		OrderResponseDto responseDto = orderService.deleteOrder(id);
+	public ResponseEntity<ApiResponse<Void>> deleteOrder(@PathVariable String id,
+		@AuthenticationPrincipal UserDetailsImpl user) {
+		orderService.deleteOrder(id, user.getUserUUID().toString());
 		return ResponseEntity.ok(ApiResponse.ok("주문을 삭제했습니다.", null));
 	}
 

--- a/src/main/java/com/sparta/first/project/eighteen/domain/orders/OrderController.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/orders/OrderController.java
@@ -19,6 +19,7 @@ import com.sparta.first.project.eighteen.domain.orders.dtos.OrderCreateRequestDt
 import com.sparta.first.project.eighteen.domain.orders.dtos.OrderResponseDto;
 import com.sparta.first.project.eighteen.domain.orders.dtos.OrderSearchRequestDto;
 import com.sparta.first.project.eighteen.domain.orders.dtos.OrderUpdateRequestDto;
+import com.sparta.first.project.eighteen.model.orders.OrderStatus;
 
 import lombok.RequiredArgsConstructor;
 
@@ -29,6 +30,13 @@ public class OrderController {
 
 	private final OrderService orderService;
 
+	/**
+	 * 주문 생성(OWNER/CUSTOMER)
+	 *
+	 * @param requestDto : 주문 정보
+	 * @param user : 로그인한 사용자
+	 * @return  :
+	 */
 	@PostMapping
 	public ResponseEntity<ApiResponse<Void>> createOrder(@RequestBody OrderCreateRequestDto requestDto,
 		@AuthenticationPrincipal UserDetailsImpl user) {
@@ -36,12 +44,24 @@ public class OrderController {
 		return ResponseEntity.ok(ApiResponse.ok("주문이 완료되었습니다.", null));
 	}
 
+	/**
+	 * 주문 조회(MASTER/MANAGER/OWNER/RIDER/CUSTOMER)
+	 *
+	 * @param id : 조회할 주문 ID
+	 * @return requestDto : 주문 내용
+	 */
 	@GetMapping("/{id}")
 	public ResponseEntity<ApiResponse<OrderResponseDto>> readOrder(@PathVariable String id) {
 		OrderResponseDto responseDto = orderService.readOrder(id);
 		return ResponseEntity.ok(ApiResponse.ok("주문을 조회했습니다.", responseDto));
 	}
 
+	/**
+	 * 주문 목록 조회(MASTER/MANAGER/OWNER)
+	 *
+	 * @param requestDto the request dto
+	 * @return  : 주문 정보
+	 */
 	@GetMapping
 	public ResponseEntity<ApiResponse<PagedModel<OrderResponseDto>>> searchOrder(
 		@ModelAttribute OrderSearchRequestDto requestDto) {
@@ -49,6 +69,13 @@ public class OrderController {
 		return ResponseEntity.ok(ApiResponse.ok("주문 목록을 조회했습니다", responseDto));
 	}
 
+	/**
+	 * 주문 수정 (MANAGER)
+	 *
+	 * @param id : 조회할 주문 ID
+	 * @param requestDto : 주문 수정 내용
+	 * @return  : 주문 정보
+	 */
 	@PatchMapping("/{id}")
 	public ResponseEntity<ApiResponse<OrderResponseDto>> updateOrder(@PathVariable String id,
 		@RequestBody OrderUpdateRequestDto requestDto) {
@@ -56,9 +83,41 @@ public class OrderController {
 		return ResponseEntity.ok(ApiResponse.ok("주문을 수정했습니다.", responseDto));
 	}
 
-	@DeleteMapping("/{id}")
+	/**
+	 * 주문 취소 (MANAGER/OWNER/CUSTOMER)
+	 *
+	 * @param id : 조회할 주문 ID
+	 * @return  : 주문 정보
+	 */
+	@DeleteMapping("/{id}/cancel")
 	public ResponseEntity<ApiResponse<OrderResponseDto>> cancelOrder(@PathVariable String id) {
 		OrderResponseDto responseDto = orderService.cancelOrder(id);
 		return ResponseEntity.ok(ApiResponse.ok("주문을 취소했습니다.", responseDto));
+	}
+
+	/**
+	 * 주문 삭제(MASTER)
+	 *
+	 * @param id : 조회할 주문 ID
+	 * @return  :
+	 */
+	@DeleteMapping("/{id}")
+	public ResponseEntity<ApiResponse<Void>> deleteOrder(@PathVariable String id) {
+		OrderResponseDto responseDto = orderService.deleteOrder(id);
+		return ResponseEntity.ok(ApiResponse.ok("주문을 삭제했습니다.", null));
+	}
+
+	/**
+	 * 주문 상태변경 (OWNER/RIDER)
+	 *
+	 * @param id : 조회할 주문 ID
+	 * @param status : 주문 변경 상태
+	 * @return  : 주문 정보
+	 */
+	@PatchMapping("/{id}/{status}")
+	public ResponseEntity<ApiResponse<OrderResponseDto>> updateOrderStatus(@PathVariable String id,
+		@PathVariable OrderStatus status) {
+		OrderResponseDto responseDto = orderService.updateOrderStatus(id, status);
+		return ResponseEntity.ok(ApiResponse.ok("주문 상태가 변경되었습니다.", responseDto));
 	}
 }

--- a/src/main/java/com/sparta/first/project/eighteen/domain/orders/OrderController.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/orders/OrderController.java
@@ -2,6 +2,7 @@ package com.sparta.first.project.eighteen.domain.orders;
 
 import org.springframework.data.web.PagedModel;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -31,12 +32,13 @@ public class OrderController {
 	private final OrderService orderService;
 
 	/**
-	 * 주문 생성(OWNER/CUSTOMER)
+	 * 주문 생성
 	 *
 	 * @param requestDto : 주문 정보
 	 * @param user : 로그인한 사용자
 	 * @return  :
 	 */
+	@PreAuthorize("hasAnyRole('OWNER','CUSTOMER')")
 	@PostMapping
 	public ResponseEntity<ApiResponse<Void>> createOrder(@RequestBody OrderCreateRequestDto requestDto,
 		@AuthenticationPrincipal UserDetailsImpl user) {
@@ -45,7 +47,7 @@ public class OrderController {
 	}
 
 	/**
-	 * 주문 조회(MASTER/MANAGER/OWNER/RIDER/CUSTOMER)
+	 * 주문 조회
 	 *
 	 * @param id : 조회할 주문 ID
 	 * @return requestDto : 주문 내용
@@ -57,11 +59,12 @@ public class OrderController {
 	}
 
 	/**
-	 * 주문 목록 조회(MASTER/MANAGER/OWNER)
+	 * 주문 목록 조회
 	 *
-	 * @param requestDto the request dto
+	 * @param requestDto : 주문 필터, 정렬, 페이징 정보
 	 * @return  : 주문 정보
 	 */
+	@PreAuthorize("hasAnyRole('MASTER','MANAGER','OWNER')")
 	@GetMapping
 	public ResponseEntity<ApiResponse<PagedModel<OrderResponseDto>>> searchOrder(
 		@ModelAttribute OrderSearchRequestDto requestDto) {
@@ -70,12 +73,13 @@ public class OrderController {
 	}
 
 	/**
-	 * 주문 수정 (MANAGER)
+	 * 주문 수정
 	 *
 	 * @param id : 조회할 주문 ID
 	 * @param requestDto : 주문 수정 내용
 	 * @return  : 주문 정보
 	 */
+	@PreAuthorize("hasRole('MANAGER')")
 	@PatchMapping("/{id}")
 	public ResponseEntity<ApiResponse<OrderResponseDto>> updateOrder(@PathVariable String id,
 		@RequestBody OrderUpdateRequestDto requestDto) {
@@ -84,11 +88,12 @@ public class OrderController {
 	}
 
 	/**
-	 * 주문 취소 (MANAGER/OWNER/CUSTOMER)
+	 * 주문 취소
 	 *
 	 * @param id : 조회할 주문 ID
 	 * @return  : 주문 정보
 	 */
+	@PreAuthorize("hasAnyRole('MANAGER','OWNER', 'CUSTOMER')")
 	@DeleteMapping("/{id}/cancel")
 	public ResponseEntity<ApiResponse<OrderResponseDto>> cancelOrder(@PathVariable String id) {
 		OrderResponseDto responseDto = orderService.cancelOrder(id);
@@ -101,6 +106,7 @@ public class OrderController {
 	 * @param id : 조회할 주문 ID
 	 * @return  :
 	 */
+	@PreAuthorize("hasRole('MASTER')")
 	@DeleteMapping("/{id}")
 	public ResponseEntity<ApiResponse<Void>> deleteOrder(@PathVariable String id,
 		@AuthenticationPrincipal UserDetailsImpl user) {
@@ -115,6 +121,7 @@ public class OrderController {
 	 * @param status : 주문 변경 상태
 	 * @return  : 주문 정보
 	 */
+	@PreAuthorize("hasAnyRole('OWNER','RIDER')")
 	@PatchMapping("/{id}/{status}")
 	public ResponseEntity<ApiResponse<OrderResponseDto>> updateOrderStatus(@PathVariable String id,
 		@PathVariable OrderStatus status) {

--- a/src/main/java/com/sparta/first/project/eighteen/domain/orders/OrderService.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/orders/OrderService.java
@@ -23,6 +23,7 @@ import com.sparta.first.project.eighteen.model.foods.FoodOptions;
 import com.sparta.first.project.eighteen.model.foods.Foods;
 import com.sparta.first.project.eighteen.model.orders.OrderDetails;
 import com.sparta.first.project.eighteen.model.orders.OrderDetailsOptions;
+import com.sparta.first.project.eighteen.model.orders.OrderStatus;
 import com.sparta.first.project.eighteen.model.orders.Orders;
 import com.sparta.first.project.eighteen.model.stores.Stores;
 import com.sparta.first.project.eighteen.model.users.Users;
@@ -109,4 +110,18 @@ public class OrderService {
 		return OrderResponseDto.fromEntity(orders);
 	}
 
+	public void deleteOrder(String id, String userId) {
+		Orders orders = ordersRepository.findById(UUID.fromString(id))
+			.orElseThrow(() -> new OrderException.OrderNotFound());
+
+		orders.delete(true, userId);
+	}
+
+	public OrderResponseDto updateOrderStatus(String id, OrderStatus status) {
+		Orders orders = ordersRepository.findById(UUID.fromString(id))
+			.orElseThrow(() -> new OrderException.OrderNotFound());
+
+		orders.changeStatus(status);
+		return OrderResponseDto.fromEntity(orders);
+	}
 }

--- a/src/main/java/com/sparta/first/project/eighteen/model/orders/Orders.java
+++ b/src/main/java/com/sparta/first/project/eighteen/model/orders/Orders.java
@@ -70,4 +70,8 @@ public class Orders extends BaseEntity {
 	public void cancel() {
 		this.status = OrderStatus.CANCELED;
 	}
+
+	public void changeStatus(OrderStatus status) {
+		this.status = status;
+	}
 }


### PR DESCRIPTION
## 관련 이슈
- #69 

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [x] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
    - 주문 주석 없음
    - 주문 취소 api만 있음
    - 주문 수정만 있음
    - 인증된 사용자는 모든 주문 api 접근 가능
- **to-be**
    - 주문 controller 주석 추가
    - 주문 취소와 삭제api 분리
    - 주문 수정과 상태 변경 api 분리  
    - 주문의 각 api는 접근 가능한 role만 preauthorize

## 코멘트
- 각 role에 따라 접근 할 수 있는 데이터 제한 추후 추가 예정 (예시: OWNER는 자기 가게의 주문 목록만 조회 가능 해야 한다) 