### PR TITLE
Refactor : 인가 방식 변경 및 액세스 토큰 발행일 검증 기능 추가

### DIFF
--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -54,6 +54,12 @@ jobs:
           distribution: 'zulu'
           java-version: '17'
 
+      - name: Set up Properties # 환경 변수 설정
+        run: |
+          cd src/main/resources
+          touch ./application-secret.yml
+          echo "${{ secrets.APPLICATION_SECRET_YML }}" >> ./application-secret.yml
+
       - name: Grant execution permission to gradle
         run: chmod +x gradlew
 

--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -58,7 +58,10 @@ jobs:
         run: |
           cd src/main/resources
           touch ./application-secret.yml
+          touch ./application.yml
+          
           echo "${{ secrets.APPLICATION_SECRET_YML }}" >> ./application-secret.yml
+          echo "${{ secrets.APPLICATION_YML }}" >> ./application.yml
 
       - name: Grant execution permission to gradle
         run: chmod +x gradlew

--- a/src/main/java/com/sparta/first/project/eighteen/common/security/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/sparta/first/project/eighteen/common/security/jwt/JwtAuthorizationFilter.java
@@ -1,6 +1,7 @@
 package com.sparta.first.project.eighteen.common.security.jwt;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -16,6 +17,7 @@ import com.sparta.first.project.eighteen.common.security.UserDetailsImpl;
 import com.sparta.first.project.eighteen.common.security.UserDetailsServiceImpl;
 import com.sparta.first.project.eighteen.model.users.Role;
 import com.sparta.first.project.eighteen.model.users.Users;
+import com.sparta.first.project.eighteen.utils.UserUtils;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -57,6 +59,9 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 		// 2. JWT에서 아이디 추출 & 권한 추출
 		String userId = jwtUtil.getUserUUID(token);
 		Role userRole = jwtUtil.getUserRole(token);
+		LocalDateTime issuedAt = jwtUtil.getIssuedAt(token);
+
+		UserUtils.checkAccessTokenBlocked(UUID.fromString(userId), issuedAt);
 
 		setAuthentication(userId, userRole);
 		filterChain.doFilter(request, response);

--- a/src/main/java/com/sparta/first/project/eighteen/common/security/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/sparta/first/project/eighteen/common/security/jwt/JwtAuthorizationFilter.java
@@ -1,6 +1,7 @@
 package com.sparta.first.project.eighteen.common.security.jwt;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -11,7 +12,10 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.sparta.first.project.eighteen.common.security.UserDetailsImpl;
 import com.sparta.first.project.eighteen.common.security.UserDetailsServiceImpl;
+import com.sparta.first.project.eighteen.model.users.Role;
+import com.sparta.first.project.eighteen.model.users.Users;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -50,25 +54,51 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 		token = token.substring(BEARER_PREFIX.length());
 		jwtUtil.validateAccessToken(token);
 
-		// 2. JWT에서 아이디 추출
+		// 2. JWT에서 아이디 추출 & 권한 추출
 		String userId = jwtUtil.getUserUUID(token);
+		Role userRole = jwtUtil.getUserRole(token);
 
-		setAuthentication(userId);
+		setAuthentication(userId, userRole);
 		filterChain.doFilter(request, response);
 	}
 
 	// 4. SecurityContext에 Authentication 객체 저장
-	private void setAuthentication(String userId) {
+	private void setAuthentication(String userId, Role userRole) {
 		SecurityContext context = SecurityContextHolder.getContext();
-		Authentication authentication = createAuthentication(userId);
+		Authentication authentication = createJwtAuthentication(userId, userRole);
 
 		context.setAuthentication(authentication);
 		SecurityContextHolder.setContext(context);
 	}
 
-	// 3. 인가해줄 Authentication 생성
+	/**
+	 * UserUUID로 DB에서 조회한 후 인증 주체를 만드는 메서드
+	 * @param userId
+	 * @return
+	 */
 	private UsernamePasswordAuthenticationToken createAuthentication(String userId) {
 		UserDetails userDetails = userDetailsService.loadUserByUserUUID(userId);
+		return new UsernamePasswordAuthenticationToken(
+			userDetails,
+			null,
+			userDetails.getAuthorities()
+		);
+	}
+
+	/**
+	 * Jwt 토큰을 기반으로 인증 주체를 만드는 메서드
+	 * @param userId
+	 * @param userRole
+	 * @return
+	 */
+	private UsernamePasswordAuthenticationToken createJwtAuthentication(String userId, Role userRole) {
+		Users jwtUser = Users.builder()
+			.userId(UUID.fromString(userId))
+			.role(userRole)
+			.build();
+
+		UserDetails userDetails = new UserDetailsImpl(jwtUser);
+
 		return new UsernamePasswordAuthenticationToken(
 			userDetails,
 			null,

--- a/src/main/java/com/sparta/first/project/eighteen/common/security/jwt/JwtUtil.java
+++ b/src/main/java/com/sparta/first/project/eighteen/common/security/jwt/JwtUtil.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 import com.sparta.first.project.eighteen.common.exception.BaseException;
+import com.sparta.first.project.eighteen.model.users.Role;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -91,11 +92,12 @@ public class JwtUtil {
 		return parseClaims(accessToken).getSubject();
 	}
 
-	// user 권한 추출
-	// public List<? extends GrantedAuthority> getUserRole(String accessToken) {
-	// 	return List.of(
-	// 		new SimpleGrantedAuthority(parseClaims(accessToken).get(AUTHORIZATION_KEY, String.class))
-	// 	);
-	//
-	// }
+	/**
+	 * Jwt 토큰 내의 auth 클레임을 기준으로 사용자 역할 부여
+	 * @param accessToken
+	 * @return 부여받은 역할군
+	 */
+	public Role getUserRole(String accessToken) {
+		return Role.from(parseClaims(accessToken).get(AUTHORIZATION_KEY, String.class));
+	}
 }

--- a/src/main/java/com/sparta/first/project/eighteen/common/security/jwt/JwtUtil.java
+++ b/src/main/java/com/sparta/first/project/eighteen/common/security/jwt/JwtUtil.java
@@ -1,5 +1,6 @@
 package com.sparta.first.project.eighteen.common.security.jwt;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 
 import javax.crypto.SecretKey;
@@ -99,5 +100,9 @@ public class JwtUtil {
 	 */
 	public Role getUserRole(String accessToken) {
 		return Role.from(parseClaims(accessToken).get(AUTHORIZATION_KEY, String.class));
+	}
+	
+	public LocalDateTime getIssuedAt(String accessToken) {
+		return LocalDateTime.from(parseClaims(accessToken).getIssuedAt().toInstant());
 	}
 }

--- a/src/main/java/com/sparta/first/project/eighteen/common/security/jwt/JwtUtil.java
+++ b/src/main/java/com/sparta/first/project/eighteen/common/security/jwt/JwtUtil.java
@@ -1,6 +1,7 @@
 package com.sparta.first.project.eighteen.common.security.jwt;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 
 import javax.crypto.SecretKey;
@@ -53,7 +54,8 @@ public class JwtUtil {
 			.subject(userUUID)
 			.claim(AUTHORIZATION_KEY, authorities)
 			.issuer(ISSUER)
-			.issuedAt(Date.from(now.toInstant().plusMillis(accessTokenExp * 1_000L)))
+			.issuedAt(now)
+			.expiration(Date.from(now.toInstant().plusMillis(accessTokenExp * 1_000L)))
 			.signWith(secretKey, Jwts.SIG.HS512)
 			.compact();
 	}
@@ -101,8 +103,12 @@ public class JwtUtil {
 	public Role getUserRole(String accessToken) {
 		return Role.from(parseClaims(accessToken).get(AUTHORIZATION_KEY, String.class));
 	}
-	
+
 	public LocalDateTime getIssuedAt(String accessToken) {
-		return LocalDateTime.from(parseClaims(accessToken).getIssuedAt().toInstant());
+		Date issuedAt = parseClaims(accessToken).getIssuedAt();
+
+		return issuedAt.toInstant()
+			.atZone(ZoneId.systemDefault())
+			.toLocalDateTime();
 	}
 }

--- a/src/main/java/com/sparta/first/project/eighteen/domain/users/AdminService.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/users/AdminService.java
@@ -15,6 +15,7 @@ import com.sparta.first.project.eighteen.domain.users.dtos.AdminUserSearchReques
 import com.sparta.first.project.eighteen.domain.users.dtos.AdminUserSearchResponseDto;
 import com.sparta.first.project.eighteen.domain.users.dtos.AdminUserUpdateRequestDto;
 import com.sparta.first.project.eighteen.model.users.Users;
+import com.sparta.first.project.eighteen.utils.UserUtils;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +32,7 @@ public class AdminService {
 
 		Page<AdminUserSearchResponseDto> users = userRepository.searchUser(requestDto, pageable)
 			.map(AdminUserSearchResponseDto::from);
-		
+
 		return new PagedModel<>(users);
 
 	}
@@ -41,6 +42,12 @@ public class AdminService {
 		Users origin = userRepository.findById(UUID.fromString(userId))
 			.orElseThrow(() -> new BaseException("유저를 찾을 수 없습니다", -1, HttpStatus.NOT_FOUND));
 
+		// 유저의 권한 변경할 때 변경 시점 기록
+		// TODO: 추후 해당 메서드에서 예외 발생 시 AOP로 기록한 아이디 취소하는 방법 고려
+		if (userRequestDto.getRole() != null) {
+			UserUtils.markUserModified(UUID.fromString(userId));
+		}
+		
 		Users updated = userRequestDto.toEntity();
 
 		origin.adminUserUpdate(updated);

--- a/src/main/java/com/sparta/first/project/eighteen/domain/users/UserService.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/users/UserService.java
@@ -11,6 +11,7 @@ import com.sparta.first.project.eighteen.common.exception.BaseException;
 import com.sparta.first.project.eighteen.domain.users.dtos.UserResponseDto;
 import com.sparta.first.project.eighteen.domain.users.dtos.UserUpdateRequestDto;
 import com.sparta.first.project.eighteen.model.users.Users;
+import com.sparta.first.project.eighteen.utils.UserUtils;
 
 import lombok.RequiredArgsConstructor;
 
@@ -45,6 +46,11 @@ public class UserService {
 	@Transactional
 	public void deleteUser(UUID userId) {
 		Users users = findUsers(userId);
+
+		// 유저의 탈퇴 시 변경 시점 기록
+		// TODO: 추후 해당 메서드에서 예외 발생 시 AOP로 기록한 아이디 취소하는 방법 고려
+		UserUtils.markUserModified(userId);
+
 		users.delete(true, userId.toString());
 	}
 

--- a/src/main/java/com/sparta/first/project/eighteen/domain/users/UsersIntegrationApp.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/users/UsersIntegrationApp.java
@@ -1,0 +1,15 @@
+package com.sparta.first.project.eighteen.domain.users;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@SpringBootApplication(scanBasePackages = {
+	"com.sparta.first.project.eighteen.domain.users",
+	"com.sparta.first.project.eighteen.common.security",
+	"com.sparta.first.project.eighteen.config"
+})
+@EnableJpaRepositories("com.sparta.first.project.eighteen.domain.users")
+@EntityScan("com.sparta.first.project.eighteen.model.users")
+public class UsersIntegrationApp {
+}

--- a/src/main/java/com/sparta/first/project/eighteen/model/users/Role.java
+++ b/src/main/java/com/sparta/first/project/eighteen/model/users/Role.java
@@ -1,5 +1,9 @@
 package com.sparta.first.project.eighteen.model.users;
 
+import java.util.Arrays;
+
+import com.sparta.first.project.eighteen.common.exception.UserException;
+
 public enum Role {
 	CUSTOMER("ROLE_CUSTOMER"), // 고객
 	OWNER("ROLE_OWNER"),       // 가게 주인
@@ -15,5 +19,17 @@ public enum Role {
 
 	public String getAuthority() {
 		return this.authority;
+	}
+
+	/**
+	 * 매칭되는 역할을 enum으로 반환해주는 메서드
+	 * @param inputRole : Jwt 토큰의 role 값
+	 * @return
+	 */
+	public static Role from(String inputRole) {
+		return Arrays.stream(Role.values())
+			.filter(role -> role.authority.equals(inputRole))
+			.findFirst()
+			.orElseThrow(UserException.UserNotFound::new);
 	}
 }

--- a/src/main/java/com/sparta/first/project/eighteen/utils/UserUtils.java
+++ b/src/main/java/com/sparta/first/project/eighteen/utils/UserUtils.java
@@ -11,6 +11,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import com.sparta.first.project.eighteen.common.exception.UserException;
 import com.sparta.first.project.eighteen.common.security.UserDetailsImpl;
 
+import lombok.extern.slf4j.Slf4j;
+
 // @Component
 
 /**
@@ -19,6 +21,7 @@ import com.sparta.first.project.eighteen.common.security.UserDetailsImpl;
  * - 이 경우 @Value 어노테이션 활용 yml 파일에서 값 주입 받을 수 있음.
  *
  */
+@Slf4j(topic = "액세스 토큰 발급 시점 검증")
 public class UserUtils {
 	// TODO: 추후 권한 변경이나 삭제의 경우 AOP로 변경
 	private static final ConcurrentHashMap<UUID, LocalDateTime> isUserModified = new ConcurrentHashMap<>();
@@ -48,6 +51,7 @@ public class UserUtils {
 		LocalDateTime modifiedAt = isUserModified.getOrDefault(userUUID, null);
 		//
 		if (modifiedAt != null && issuedAt.isBefore(modifiedAt)) {
+			log.error("[ERROR] 권한 변경 / 탈퇴 이전에 발급된 토큰입니다.");
 			throw new UserException.UserNotFound();
 		}
 
@@ -69,6 +73,7 @@ public class UserUtils {
 			return;
 		}
 
+		log.info("now = {}, 변경 시점 + 만료기간 = {}", now, modifiedAtPlusAccessTokenExp);
 		// 현재 시점이 변경 시점 + 만료 기간 보다 이후라면 아무리 빨리 발급해도 변경 시점 이후에 발급한 것.
 		isUserModified.remove(userUUID);
 

--- a/src/main/java/com/sparta/first/project/eighteen/utils/UserUtils.java
+++ b/src/main/java/com/sparta/first/project/eighteen/utils/UserUtils.java
@@ -1,0 +1,86 @@
+package com.sparta.first.project.eighteen.utils;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.sparta.first.project.eighteen.common.exception.UserException;
+import com.sparta.first.project.eighteen.common.security.UserDetailsImpl;
+
+// @Component
+
+/**
+ * Util 클래스를 static 메서드로만 구성할지?
+ * 빈으로 등록해서 싱글톤으로 관리할지? <br>
+ * - 이 경우 @Value 어노테이션 활용 yml 파일에서 값 주입 받을 수 있음.
+ *
+ */
+public class UserUtils {
+	// TODO: 추후 권한 변경이나 삭제의 경우 AOP로 변경
+	private static final ConcurrentHashMap<UUID, LocalDateTime> isUserModified = new ConcurrentHashMap<>();
+
+	/**
+	 * 유저의 권한 변경 또는 삭제 시 해당 시간 기록 <br>
+	 * 이후 인가 과정에서는 먼저 UUID로 변경 내역이 있는지 확인
+	 */
+	public static void markUserModified() {
+		UserDetailsImpl userDetails = getUserDetails();
+
+		UUID userUUID = userDetails.getUserUUID();
+
+		LocalDateTime now = LocalDateTime.now();
+
+		// 권한 변경이나 삭제 시간 매핑
+		isUserModified.put(userUUID, now);
+	}
+
+	/**
+	 * userUUID로 조회 했을 때 <br>
+	 * - null인 경우 -> 변경된 적이 없음, 정상적으로 인가 <br>
+	 * - 액세스 토큰 발급 시점 >= 유저 변경 시점 -> 변경 내용 반영되었기 때문에 정상 처리 <br>
+	 * - 액세스 토큰 발급 시점 < 유저 변경 시점 -> 변경 이전에 발급한 토큰이기 때문에 반영이 되어있지 않음, 차단
+	 * @param userUUID : 검색할 유저 UUID
+	 */
+	public static void checkAccessTokenBlocked(UUID userUUID, LocalDateTime issuedAt) {
+		LocalDateTime modifiedAt = isUserModified.getOrDefault(userUUID, null);
+		//
+		if (modifiedAt != null && issuedAt.isBefore(modifiedAt)) {
+			throw new UserException.UserNotFound();
+		}
+
+		if (modifiedAt != null) {
+			deleteIfExpired(userUUID, modifiedAt);
+		}
+	}
+
+	/**
+	 * 추후 scheduler나 Redis TTL 사용해서 이미 만료기간이 지난 경우 제거
+	 */
+	public static void deleteIfExpired(UUID userUUID, LocalDateTime modifiedAt) {
+		LocalDateTime now = LocalDateTime.now();
+		Duration duration = Duration.ofMillis(1209600 * 1_000L);
+		LocalDateTime modifiedAtPlusAccessTokenExp = modifiedAt.plus(duration);
+
+		// 현재 시점이 변경 시점 + 만료 기간 보다 이전일 경우 남겨둬야 함.
+		if (now.isBefore(modifiedAtPlusAccessTokenExp)) {
+			return;
+		}
+
+		// 현재 시점이 변경 시점 + 만료 기간 보다 이후라면 아무리 빨리 발급해도 변경 시점 이후에 발급한 것.
+		isUserModified.remove(userUUID);
+
+	}
+
+	/**
+	 * 로그인 이후 상황에서 인증 주체 가져오는 메서드
+	 * @return 인증에 성공한 UserDetailsImpl
+	 */
+	public static UserDetailsImpl getUserDetails() {
+		SecurityContext context = SecurityContextHolder.getContext();
+		return (UserDetailsImpl)context.getAuthentication().getPrincipal();
+	}
+}

--- a/src/main/java/com/sparta/first/project/eighteen/utils/UserUtils.java
+++ b/src/main/java/com/sparta/first/project/eighteen/utils/UserUtils.java
@@ -14,7 +14,7 @@ import com.sparta.first.project.eighteen.common.security.UserDetailsImpl;
 // @Component
 
 /**
- * Util 클래스를 static 메서드로만 구성할지?
+ * Util 클래스를 static 메서드로만 구성할지? <br>
  * 빈으로 등록해서 싱글톤으로 관리할지? <br>
  * - 이 경우 @Value 어노테이션 활용 yml 파일에서 값 주입 받을 수 있음.
  *
@@ -24,14 +24,13 @@ public class UserUtils {
 	private static final ConcurrentHashMap<UUID, LocalDateTime> isUserModified = new ConcurrentHashMap<>();
 
 	/**
-	 * 유저의 권한 변경 또는 삭제 시 해당 시간 기록 <br>
+	 * 유저의 권한 변경 또는 탈퇴 시 해당 시간 기록 <br>
+	 * @Param userUUID <br>
+	 * - 관리자가 유저 권한 변경 하는 경우 PathVariable로 전달받은 값 <br>
+	 * - 유저가 탈퇴한 경우 유저 본인의 식별자 값  <br>
 	 * 이후 인가 과정에서는 먼저 UUID로 변경 내역이 있는지 확인
 	 */
-	public static void markUserModified() {
-		UserDetailsImpl userDetails = getUserDetails();
-
-		UUID userUUID = userDetails.getUserUUID();
-
+	public static void markUserModified(UUID userUUID) {
 		LocalDateTime now = LocalDateTime.now();
 
 		// 권한 변경이나 삭제 시간 매핑

--- a/src/test/java/com/sparta/first/project/eighteen/domain/users/DeletedUserTest.java
+++ b/src/test/java/com/sparta/first/project/eighteen/domain/users/DeletedUserTest.java
@@ -1,34 +1,141 @@
 package com.sparta.first.project.eighteen.domain.users;
 
-import org.junit.jupiter.api.BeforeEach;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.context.WebApplicationContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.first.project.eighteen.domain.users.dtos.LoginRequestDto;
+import com.sparta.first.project.eighteen.domain.users.dtos.UserUpdateRequestDto;
+import com.sparta.first.project.eighteen.model.users.Users;
 
 @Transactional
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@WebMvcTest({UserController.class})
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
 public class DeletedUserTest {
 
 	@Autowired
-	WebApplicationContext ac;
-
 	MockMvc mvc;
 
-	@Autowired
+	PasswordEncoder passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
+
+	@MockitoBean
 	UserRepository userRepository;
 
 	@Autowired
-	UserService userService;
+	private UserService userService;
 
-	@BeforeEach
-	void setUp() {
-		mvc = MockMvcBuilders.webAppContextSetup(ac)
+	private ObjectMapper objectMapper = new ObjectMapper();
+
+	UUID userId = UUID.fromString("fccf3448-03c7-47a4-a108-ce6c39815a37");
+	Users customer = Users.builder()
+		.userId(userId)
+		.username("customer")
+		.userPassword(passwordEncoder.encode("customer"))
+		// .role(Role.CUSTOMER)
+		.isDeleted(true)
+		.build();
+
+	@BeforeAll
+	void init() {
+		BDDMockito.given(userRepository.findById(BDDMockito.any(UUID.class))).willReturn(Optional.of(customer));
+		// 시작 시 유저 삭제 처리
+		userService.deleteUser(userId);
+	}
+
+	/**
+	 * 삭제 이전에 발급받은 토큰으로 로그인 시도 시 차단
+	 */
+	@Test
+	@DisplayName("삭제 회원 - 로그인")
+	void deleteUserLoginTest() throws Exception {
+		// given
+		LoginRequestDto requestDto = new LoginRequestDto("customer", "customer");
+		BDDMockito.given(userRepository.findByUsername(BDDMockito.anyString())).willReturn(Optional.of(customer));
+
+		// when
+		ResultActions perform = mvc.perform(
+			MockMvcRequestBuilders.post("/api/v1/auth/sign-in")
+				.content(objectMapper.writeValueAsString(requestDto))
+				.contentType(MediaType.APPLICATION_JSON)
+		);
+
+		// then
+		perform.andExpect(MockMvcResultMatchers.status().is4xxClientError())
+			.andDo(MockMvcResultHandlers.print());
+
+	}
+
+	@Test
+	@DisplayName("삭제 회원 - 회원 조회")
+	void deletedUserInfoTest() throws Exception {
+		// given
+		String token = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJmY2NmMzQ0OC0wM2M3LTQ3YTQtYTEwOC1jZTZjMzk4MTVhMzciLCJhdXRoIjoiUk9MRV9DVVNUT01FUiIsImlzcyI6ImVpZ2h0ZWVuIiwiaWF0IjoxNzQwMjAzMTg2LCJleHAiOjE3NDE0MTI3ODZ9.vjC1_y3msUKVlaZqQhAkHL7LwoVFvSJ6mkt2jDn-OnY5J-eH2Rrp1lkqNGWe2SH275AQUwUQFzqOD-g0C6XOGw";
+
+		// when
+		ResultActions perform = mvc.perform(MockMvcRequestBuilders.get("/api/admin/v1/users")
+			.header("Authorization", "Bearer " + token)
+		);
+
+		// then
+		perform.andExpect(MockMvcResultMatchers.status().is4xxClientError())
+			.andDo(MockMvcResultHandlers.print());
+	}
+
+	@Test
+	@DisplayName("삭제 회원 - 회원 수정")
+	void deletedUserModifyTest() throws Exception {
+		// given
+		String token = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJmY2NmMzQ0OC0wM2M3LTQ3YTQtYTEwOC1jZTZjMzk4MTVhMzciLCJhdXRoIjoiUk9MRV9DVVNUT01FUiIsImlzcyI6ImVpZ2h0ZWVuIiwiaWF0IjoxNzQwMjAzMTg2LCJleHAiOjE3NDE0MTI3ODZ9.vjC1_y3msUKVlaZqQhAkHL7LwoVFvSJ6mkt2jDn-OnY5J-eH2Rrp1lkqNGWe2SH275AQUwUQFzqOD-g0C6XOGw";
+		UserUpdateRequestDto requestDto = UserUpdateRequestDto.builder()
+			.email("test123@test.com")
 			.build();
+		// when
+		ResultActions perform = mvc.perform(MockMvcRequestBuilders.put("/api/admin/v1/users")
+			.content(objectMapper.writeValueAsString(requestDto)).contentType(MediaType.APPLICATION_JSON)
+			.header("Authorization", "Bearer " + token)
+		);
+
+		// then
+		perform.andExpect(MockMvcResultMatchers.status().is4xxClientError())
+			.andDo(MockMvcResultHandlers.print());
+	}
+
+	@Test
+	@DisplayName("삭제 회원 - 회원 삭제")
+	void deletedUserDeleteTest() throws Exception {
+		// given
+		String token = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJmY2NmMzQ0OC0wM2M3LTQ3YTQtYTEwOC1jZTZjMzk4MTVhMzciLCJhdXRoIjoiUk9MRV9DVVNUT01FUiIsImlzcyI6ImVpZ2h0ZWVuIiwiaWF0IjoxNzQwMjAzMTg2LCJleHAiOjE3NDE0MTI3ODZ9.vjC1_y3msUKVlaZqQhAkHL7LwoVFvSJ6mkt2jDn-OnY5J-eH2Rrp1lkqNGWe2SH275AQUwUQFzqOD-g0C6XOGw";
+
+		// when
+		ResultActions perform = mvc.perform(MockMvcRequestBuilders.delete("/api/admin/v1/users")
+			.header("Authorization", "Bearer " + token)
+		);
+
+		// then
+		perform.andExpect(MockMvcResultMatchers.status().is4xxClientError())
+			.andDo(MockMvcResultHandlers.print());
 	}
 
 }

--- a/src/test/java/com/sparta/first/project/eighteen/domain/users/LoginTest.java
+++ b/src/test/java/com/sparta/first/project/eighteen/domain/users/LoginTest.java
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -37,17 +36,14 @@ public class LoginTest {
 	@MockitoBean
 	JwtUtil jwtUtil;
 
-	@Autowired
-	PasswordEncoder passwordEncoder;
-
 	ObjectMapper objectMapper = new ObjectMapper();
 
 	@ParameterizedTest
 	@DisplayName("로그인 성공 테스트")
 	@CsvSource(value = {
-		"customer:customer:eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJmY2NmMzQ0OC0wM2M3LTQ3YTQtYTEwOC1jZTZjMzk4MTVhMzciLCJhdXRoIjoiUk9MRV9DVVNUT01FUiIsImlzcyI6ImVpZ2h0ZWVuIiwiaWF0IjoxNzQxMDA5NTYzfQ.DFavV8v-1o3wyui2W8tnASsRU-DpT9FRc6yImHVWD7pem0SWmnuRL5gOfWky51WiDXZ0aN2WT8J24UngPABxpQ",
-		"owner:owner:eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIzYTUwM2NkOS04M2IyLTQzNzQtOTQwNS1lMmRlZThjNTZiMWMiLCJhdXRoIjoiUk9MRV9PV05FUiIsImlzcyI6ImVpZ2h0ZWVuIiwiaWF0IjoxNzQxMDA5NTk1fQ.y7cTaynw75ksi2vuPMQpg2TCobPMVW1YYhdIYGZxauLnRohRnFjxx03_7ZFOotSLQa7VX78jto-1QxctrD02gQ",
-		"manager:manager:eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJmYWUwNzZlMy01ODQyLTQyMWYtYTExOS1iNjQ2NjYwM2I5NjQiLCJhdXRoIjoiUk9MRV9NQU5BR0VSIiwiaXNzIjoiZWlnaHRlZW4iLCJpYXQiOjE3NDEwMDk1MDV9.Hv0871zRgqaOMofrlaxJ8agxOCPSQ5J_g8dLba8yI0sNB5GxYxU7n8dTURnlXOnUezNRPsXfYbhus79XsY_inA"
+		"customer:customer:eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJmY2NmMzQ0OC0wM2M3LTQ3YTQtYTEwOC1jZTZjMzk4MTVhMzciLCJhdXRoIjoiUk9MRV9DVVNUT01FUiIsImlzcyI6ImVpZ2h0ZWVuIiwiaWF0IjoxNzQwMjAzMTg2LCJleHAiOjE3NDE0MTI3ODZ9.vjC1_y3msUKVlaZqQhAkHL7LwoVFvSJ6mkt2jDn-OnY5J-eH2Rrp1lkqNGWe2SH275AQUwUQFzqOD-g0C6XOGw",
+		"owner:owner:eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIzYTUwM2NkOS04M2IyLTQzNzQtOTQwNS1lMmRlZThjNTZiMWMiLCJhdXRoIjoiUk9MRV9PV05FUiIsImlzcyI6ImVpZ2h0ZWVuIiwiaWF0IjoxNzQwMjAzMjQ3LCJleHAiOjE3NDE0MTI4NDd9.HAadDH7zBcWmjSQm9E4M4GPjRHMeB52Wcn5bJt04cM9cIWDsGrdHJ2VI25hFEj4WMv3KuqiVW_OCMjUul7BQtw",
+		"manager:manager:eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJmYWUwNzZlMy01ODQyLTQyMWYtYTExOS1iNjQ2NjYwM2I5NjQiLCJhdXRoIjoiUk9MRV9NQU5BR0VSIiwiaXNzIjoiZWlnaHRlZW4iLCJpYXQiOjE3NDAyMDMyODEsImV4cCI6MTc0MTQxMjg4MX0.e3qGQH0qM8RX2rSzo3oF-5PauvQq1XV9kHKLxgSDl5e1GURIn3a8_Mww7Y5HRcYZlBxq3I-ilglyt7DMBLbdlg"
 	}, delimiter = ':')
 	public void loginSuccessTest(String username, String password, String accToken) throws Exception {
 		// given


### PR DESCRIPTION
## 관련 이슈
- #78 

## 변경 타입
- [ ] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
    - 매 인가 단계에서 DB를 직접 조회해 JWT의 장점을 제대로 활용하지 못하던 문제가 있었음.

- **to-be**
    - 더이상 DB를 거치지 않고 JWT 토큰에서 유저 식별자, 권한을 뽑아 인증 주체를 생성하도록 변경했음. 
    - 권한 변경 및 회원 삭제와 같이 액세스 토큰 유효기간 내에서 중대한 변경이 발생할 경우 변경 시점을 기록해 이전의 토큰을 무효로 처리함.

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)