### PR TITLE
Fix: Orders 생성, 수정 수정

### DIFF
--- a/src/main/java/com/sparta/first/project/eighteen/domain/orders/OrderController.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/orders/OrderController.java
@@ -42,10 +42,10 @@ public class OrderController {
 	 */
 	@PreAuthorize("hasAnyRole('OWNER','CUSTOMER')")
 	@PostMapping
-	public ResponseEntity<ApiResponse<Void>> createOrder(@Valid @RequestBody OrderCreateRequestDto requestDto,
+	public ResponseEntity<ApiResponse<String>> createOrder(@Valid @RequestBody OrderCreateRequestDto requestDto,
 		@AuthenticationPrincipal UserDetailsImpl user) {
-		orderService.createOrder(requestDto, user.getUserUUID());
-		return ResponseEntity.ok(ApiResponse.ok("주문이 완료되었습니다.", null));
+		String orderId = orderService.createOrder(requestDto, user.getUserUUID());
+		return ResponseEntity.ok(ApiResponse.ok("주문이 완료되었습니다.", orderId));
 	}
 
 	/**

--- a/src/main/java/com/sparta/first/project/eighteen/domain/orders/OrderService.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/orders/OrderService.java
@@ -42,7 +42,7 @@ public class OrderService {
 	private final UserRepository userRepository;
 	private final FoodsRepository foodsRepository;
 
-	public void createOrder(OrderCreateRequestDto requestDto, UUID userId) {
+	public String createOrder(OrderCreateRequestDto requestDto, UUID userId) {
 		Stores store = storeRepository.findById(UUID.fromString(requestDto.getStoreId()))
 			.orElseThrow(() -> new StoreException.StoreNotFound());
 
@@ -74,6 +74,8 @@ public class OrderService {
 				orderDetailsOptionsRepository.save(orderDetailsOptions);
 			}
 		}
+
+		return order.getId().toString();
 	}
 
 	@Transactional(readOnly = true)
@@ -97,6 +99,7 @@ public class OrderService {
 			.orElseThrow(() -> new OrderException.OrderNotFound());
 
 		orders.update(requestDto);
+		
 		return OrderResponseDto.fromEntity(orders);
 	}
 

--- a/src/main/java/com/sparta/first/project/eighteen/domain/orders/dtos/OrderUpdateRequestDto.java
+++ b/src/main/java/com/sparta/first/project/eighteen/domain/orders/dtos/OrderUpdateRequestDto.java
@@ -1,9 +1,6 @@
 package com.sparta.first.project.eighteen.domain.orders.dtos;
 
-import java.util.List;
-
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Min;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -11,13 +8,11 @@ import lombok.Setter;
 @Getter
 public class OrderUpdateRequestDto {
 
-	@NotBlank
-	String status;
-
 	String noteToStore;
 
 	String noteToDelivery;
 
-	@NotNull
-	List<OrderDetailsUpdateRequestDto> orderDetails;
+	@Min(10)
+	int totalPrice;
+
 }

--- a/src/main/java/com/sparta/first/project/eighteen/model/orders/Orders.java
+++ b/src/main/java/com/sparta/first/project/eighteen/model/orders/Orders.java
@@ -64,9 +64,9 @@ public class Orders extends BaseEntity {
 	private List<OrderDetails> orderDetails;
 
 	public void update(OrderUpdateRequestDto requestDto) {
-		this.status = OrderStatus.valueOf(requestDto.getStatus());
 		this.noteToStore = requestDto.getNoteToStore();
 		this.noteToDelivery = requestDto.getNoteToDelivery();
+		this.totalPrice = requestDto.getTotalPrice();
 	}
 
 	public void cancel() {


### PR DESCRIPTION
## 관련 이슈
- #86

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- As-is
  - 주문 생성 후 반환 객체/값 없음
  - 수정 할 수 없는 주문 갯수와 품목 리스트를 주문 수정 요청 시 요구

- To-be
  - 주문 생성 후 해당 주문 OrderId를 반환 받음
  - 주문 수정 시 수정 가능한 항목만 요구

## 코멘트